### PR TITLE
Various backports and additional updates

### DIFF
--- a/OmniBLE/Bluetooth/Pair/LTKExchanger.swift
+++ b/OmniBLE/Bluetooth/Pair/LTKExchanger.swift
@@ -56,7 +56,7 @@ class LTKExchanger {
         try throwOnSendError(sps1.message, LTKExchanger.SPS1)
 
         log.debug("Reading sps1")
-        let podSps1 = try manager.readMessage()
+        let podSps1 = try manager.readMessagePacket()
         guard let _ = podSps1 else {
             throw PodProtocolError.pairingException("Could not read SPS1")
         }
@@ -74,7 +74,7 @@ class LTKExchanger {
         )
         try throwOnSendError(sps2.message, LTKExchanger.SPS2)
 
-        let podSps2 = try manager.readMessage()
+        let podSps2 = try manager.readMessagePacket()
         guard let _ = podSps2 else {
             throw PodProtocolError.pairingException("Could not read SPS2")
         }
@@ -90,12 +90,12 @@ class LTKExchanger {
             keys: [LTKExchanger.SP0GP0],
             payloads: [Data()]
         )
-        let result = manager.sendMessage(sp0gp0.message)
+        let result = manager.sendMessagePacket(sp0gp0.message)
         guard case .sentWithAcknowledgment = result else {
             throw PodProtocolError.pairingException("Error sending SP0GP0: \(result)")
         }
 
-        let p0 = try manager.readMessage()
+        let p0 = try manager.readMessagePacket()
         guard let _ = p0 else {
             throw PodProtocolError.pairingException("Could not read P0")
         }
@@ -113,7 +113,7 @@ class LTKExchanger {
     }
 
     private func throwOnSendError(_ msg: MessagePacket, _ msgType: String) throws {
-        let result = manager.sendMessage(msg)
+        let result = manager.sendMessagePacket(msg)
         guard case .sentWithAcknowledgment = result else {
             throw PodProtocolError.pairingException("Send failure: \(result)")
         }

--- a/OmniBLE/Bluetooth/PeripheralManager+OmniBLE.swift
+++ b/OmniBLE/Bluetooth/PeripheralManager+OmniBLE.swift
@@ -40,7 +40,7 @@ extension PeripheralManager {
         try setNotifyValue(true, for: dataChar, timeout: .seconds(2))
     }
         
-    func sendMessage(_ message: MessagePacket, _ forEncryption: Bool = false) -> SendMessageResult {
+    func sendMessagePacket(_ message: MessagePacket, _ forEncryption: Bool = false) -> SendMessageResult {
         dispatchPrecondition(condition: .onQueue(queue))
         
         var didSend = false
@@ -75,7 +75,7 @@ extension PeripheralManager {
     }
     
     /// - Throws: PeripheralManagerError
-    func readMessage() throws -> MessagePacket? {
+    func readMessagePacket() throws -> MessagePacket? {
         dispatchPrecondition(condition: .onQueue(queue))
 
         var packet: MessagePacket?

--- a/OmniBLE/Bluetooth/Session/SessionEstablisher.swift
+++ b/OmniBLE/Bluetooth/Session/SessionEstablisher.swift
@@ -54,11 +54,11 @@ class SessionEstablisher {
     func negotiateSessionKeys() throws -> SessionResult {
         msgSeq += 1
         let challenge = try eapAkaChallenge()
-        let sendResult = manager.sendMessage(challenge)
+        let sendResult = manager.sendMessagePacket(challenge)
         guard case .sentWithAcknowledgment = sendResult else {
             throw SessionEstablishmentException.CommunicationError("Could not send the EAP AKA challenge: $sendResult")
         }
-        guard let challengeResponse = try manager.readMessage() else {
+        guard let challengeResponse = try manager.readMessagePacket() else {
             throw SessionEstablishmentException.CommunicationError("Could not establish session")
         }
 
@@ -72,7 +72,7 @@ class SessionEstablisher {
 
         msgSeq += 1
         let success = eapSuccess()
-        let _ = manager.sendMessage(success)
+        let _ = manager.sendMessagePacket(success)
 
         return .SessionKeys(SessionKeys(
             ck: milenage.ck,

--- a/OmniBLE/OmnipodCommon/MessageBlocks/DetailedStatus.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/DetailedStatus.swift
@@ -119,8 +119,7 @@ extension DetailedStatus: CustomDebugStringConvertible {
             "* bolusNotDelivered: \(bolusNotDelivered.twoDecimals) U",
             "* lastProgrammingMessageSeqNum: \(lastProgrammingMessageSeqNum)",
             "* totalInsulinDelivered: \(totalInsulinDelivered.twoDecimals) U",
-            "* faultEventCode: \(faultEventCode.description)",
-            "* reservoirLevel: \(reservoirLevel > Pod.maximumReservoirReading ? "50+" : reservoirLevel.twoDecimals) U",
+            "* reservoirLevel: \(reservoirLevelString(reservoirLevel)) U",
             "* timeActive: \(timeActive.stringValue)",
             "* unacknowledgedAlerts: \(unacknowledgedAlerts)",
             "",
@@ -134,6 +133,7 @@ extension DetailedStatus: CustomDebugStringConvertible {
         }
         if faultEventCode.faultType != .noFaults {
             result += [
+                "* faultEventCode: \(faultEventCode.description)",
                 "* faultAccessingTables: \(faultAccessingTables)",
                 "* faultEventTimeSinceActivation: \(faultEventTimeSinceActivation?.stringValue ?? "NA")",
                 "* errorEventInfo: \(errorEventInfo?.description ?? "NA")",
@@ -220,4 +220,24 @@ public struct ErrorEventInfo: CustomStringConvertible, Equatable {
         self.immediateBolusInProgress = (rawValue & 0x10) != 0
         self.podProgressStatus = PodProgressStatus(rawValue: rawValue & 0xF)!
     }
+}
+
+//
+// Convenience functions for dealing with ReserviorLevel readings.
+// Historically these were optionals with no reading representing 50+.
+//
+public func isValidReservoirLevelValue(_ reservoirLevel: Double?) -> Bool
+{
+    if let reservoirLevel = reservoirLevel, reservoirLevel <= Pod.maximumReservoirReading {
+        return true
+    }
+    return false
+}
+
+public func reservoirLevelString(_ reservoirLevel: Double?) -> String
+{
+    if isValidReservoirLevelValue(reservoirLevel) {
+        return reservoirLevel!.twoDecimals
+    }
+    return "50+"
 }

--- a/OmniBLE/OmnipodCommon/MessageBlocks/StatusResponse.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/StatusResponse.swift
@@ -95,7 +95,7 @@ public struct StatusResponse : MessageBlock {
 
 extension StatusResponse: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return "StatusResponse(deliveryStatus:\(deliveryStatus), progressStatus:\(podProgressStatus), timeActive:\(timeActive.stringValue), reservoirLevel:\(String(describing: reservoirLevel)), delivered:\(insulinDelivered), bolusNotDelivered:\(bolusNotDelivered), lastProgrammingMessageSeqNum:\(lastProgrammingMessageSeqNum), alerts:\(alerts))"
+        return "StatusResponse(deliveryStatus:\(deliveryStatus.description), progressStatus:\(podProgressStatus), timeActive:\(timeActive.stringValue), reservoirLevel:\(reservoirLevelString(reservoirLevel)), insulinDelivered:\(insulinDelivered.twoDecimals), bolusNotDelivered:\(bolusNotDelivered.twoDecimals), lastProgrammingMessageSeqNum:\(lastProgrammingMessageSeqNum), alerts:\(alerts)"
     }
 }
 

--- a/OmniBLE/OmnipodCommon/PendingCommand.swift
+++ b/OmniBLE/OmnipodCommon/PendingCommand.swift
@@ -95,8 +95,8 @@ public enum StartProgram: RawRepresentable {
 public enum PendingCommand: RawRepresentable, Equatable {
     public typealias RawValue = [String: Any]
 
-    case program(StartProgram, Int, Date)
-    case stopProgram(CancelDeliveryCommand.DeliveryType, Int, Date)
+    case program(StartProgram, Int, Date, Bool = true)
+    case stopProgram(CancelDeliveryCommand.DeliveryType, Int, Date, Bool = true)
     
     private enum PendingCommandType: Int {
         case startProgram, stopProgram
@@ -104,19 +104,37 @@ public enum PendingCommand: RawRepresentable, Equatable {
 
     public var commandDate: Date {
         switch self {
-        case .program(_, _, let date):
+        case .program(_, _, let date, _):
             return date
-        case .stopProgram(_, _, let date):
+        case .stopProgram(_, _, let date, _):
             return date
         }
     }
 
     public var sequence: Int {
         switch self {
-        case .program(_, let sequence, _):
+        case .program(_, let sequence, _, _):
             return sequence
-        case .stopProgram(_, let sequence, _):
+        case .stopProgram(_, let sequence, _, _):
             return sequence
+        }
+    }
+
+    public var isInFlight: Bool {
+        switch self {
+        case .program(_, _, _, let inflight):
+            return inflight
+        case .stopProgram(_, _, _, let inflight):
+            return inflight
+        }
+    }
+
+    public var commsFinished: PendingCommand {
+        switch self {
+        case .program(let program, let sequence, let date, _):
+            return PendingCommand.program(program, sequence, date, false)
+        case .stopProgram(let program, let sequence, let date, _):
+            return PendingCommand.stopProgram(program, sequence, date, false)
         }
     }
 
@@ -133,6 +151,7 @@ public enum PendingCommand: RawRepresentable, Equatable {
             return nil
         }
 
+        let inflight = rawValue["inflight"] as? Bool ?? false
 
         switch PendingCommandType(rawValue: rawPendingCommandType) {
         case .startProgram?:
@@ -140,7 +159,7 @@ public enum PendingCommand: RawRepresentable, Equatable {
                 return nil
             }
             if let program = StartProgram(rawValue: rawUnacknowledgedProgram) {
-                self = .program(program, sequence, commandDate)
+                self = .program(program, sequence, commandDate, inflight)
             } else {
                 return nil
             }
@@ -149,7 +168,7 @@ public enum PendingCommand: RawRepresentable, Equatable {
                 return nil
             }
             let stopProgram = CancelDeliveryCommand.DeliveryType(rawValue: rawDeliveryType)
-            self = .stopProgram(stopProgram, sequence, commandDate)
+            self = .stopProgram(stopProgram, sequence, commandDate, inflight)
         default:
             return nil
         }
@@ -159,15 +178,17 @@ public enum PendingCommand: RawRepresentable, Equatable {
         var rawValue: RawValue = [:]
         
         switch self {
-        case .program(let program, let sequence, let date):
+        case .program(let program, let sequence, let date, let inflight):
             rawValue["type"] = PendingCommandType.startProgram.rawValue
             rawValue["date"] = date
             rawValue["sequence"] = sequence
+            rawValue["inflight"] = inflight
             rawValue["unacknowledgedProgram"] = program.rawValue
-        case .stopProgram(let stopProgram, let sequence, let date):
+        case .stopProgram(let stopProgram, let sequence, let date, let inflight):
             rawValue["type"] = PendingCommandType.stopProgram.rawValue
             rawValue["date"] = date
             rawValue["sequence"] = sequence
+            rawValue["inflight"] = inflight
             rawValue["unacknowledgedStopProgram"] = stopProgram.rawValue
         }
         return rawValue
@@ -175,10 +196,10 @@ public enum PendingCommand: RawRepresentable, Equatable {
     
     public static func == (lhs: PendingCommand, rhs: PendingCommand) -> Bool {
         switch(lhs, rhs) {
-        case (.program(let lhsProgram, let lhsSequence, let lhsDate), .program(let rhsProgram, let rhsSequence, let rhsDate)):
-            return lhsProgram == rhsProgram && lhsSequence == rhsSequence && lhsDate == rhsDate
-        case (.stopProgram(let lhsStopProgram, let lhsSequence, let lhsDate), .stopProgram(let rhsStopProgram, let rhsSequence, let rhsDate)):
-            return lhsStopProgram == rhsStopProgram && lhsSequence == rhsSequence && lhsDate == rhsDate
+        case (.program(let lhsProgram, let lhsSequence, let lhsDate, let lhsInflight), .program(let rhsProgram, let rhsSequence, let rhsDate, let rhsInflight)):
+            return lhsProgram == rhsProgram && lhsSequence == rhsSequence && lhsDate == rhsDate && lhsInflight == rhsInflight
+        case (.stopProgram(let lhsStopProgram, let lhsSequence, let lhsDate, let lhsInflight), .stopProgram(let rhsStopProgram, let rhsSequence, let rhsDate, let rhsInflight)):
+            return lhsStopProgram == rhsStopProgram && lhsSequence == rhsSequence && lhsDate == rhsDate && lhsInflight == rhsInflight
         default:
             return false
         }

--- a/OmniBLE/PumpManagerUI/OmniBLEHUDProvider.swift
+++ b/OmniBLE/PumpManagerUI/OmniBLEHUDProvider.swift
@@ -209,9 +209,9 @@ internal class OmniBLEHUDProvider: NSObject, HUDProvider, PodStateObserver {
 
 extension Double {
     func asReservoirPercentage() -> Double {
-        if self > Pod.maximumReservoirReading {
-            return 1
+        if isValidReservoirLevelValue(self) {
+            return min(1, max(0, self / Pod.reservoirCapacity))
         }
-        return min(1, max(0, self / Pod.reservoirCapacity))
+        return 1
     }
 }

--- a/OmniBLE/PumpManagerUI/ViewControllers/CommandResponseViewController.swift
+++ b/OmniBLE/PumpManagerUI/ViewControllers/CommandResponseViewController.swift
@@ -62,7 +62,7 @@ extension CommandResponseViewController {
 
         result += String(format: LocalizedString("Pulse Count: %1$d\n", comment: "The format string for Pulse Count (1: pulse count)"), Int(round(status.totalInsulinDelivered / Pod.pulseSize)))
 
-        result += String(format: LocalizedString("Reservoir Level: %1$@ U\n", comment: "The format string for Reservoir Level: (1: reservoir level string)"), status.reservoirLevel > Pod.maximumReservoirReading ? "50+" : status.reservoirLevel.twoDecimals)
+        result += String(format: LocalizedString("Reservoir Level: %1$@ U\n", comment: "The format string for Reservoir Level: (1: reservoir level string)"), reservoirLevelString(status.reservoirLevel))
 
         result += String(format: LocalizedString("Last Bolus Not Delivered: %1$@ U\n", comment: "The format string for Last Bolus Not Delivered: (1: bolus not delivered string)"), status.bolusNotDelivered.twoDecimals)
 
@@ -106,7 +106,7 @@ extension CommandResponseViewController {
 
     static func readPodStatus(pumpManager: OmniBLEPumpManager) -> T {
         return T { (completionHandler) -> String in
-            pumpManager.readPodStatus() { (result) in
+            pumpManager.getDetailedStatus() { (result) in
                 DispatchQueue.main.async {
                     switch result {
                     case .success(let status):

--- a/OmniBLE/PumpManagerUI/ViewControllers/OmniBLESettingsViewController.swift
+++ b/OmniBLE/PumpManagerUI/ViewControllers/OmniBLESettingsViewController.swift
@@ -991,14 +991,6 @@ private extension UITableViewCell {
             detailTextLabel?.text = LocalizedString("Unknown", comment: "The detail text for delivered insulin when no measurement is available")
             return
         }
-        if reservoirLevel > Pod.maximumReservoirReading {
-            if let units = insulinFormatter.string(from: Pod.maximumReservoirReading) {
-                detailTextLabel?.text = String(format: LocalizedString("%@+ U", comment: "Format string for reservoir reading when above the maximum reading. (1: The localized amount)"), units)
-            }
-        } else {
-            if let units = insulinFormatter.string(from: reservoirLevel) {
-                detailTextLabel?.text = String(format: LocalizedString("%@ U", comment: "Format string for insulin remaining in reservoir. (1: The localized amount)"), units)
-            }
-        }
+        detailTextLabel?.text = reservoirLevelString(reservoirLevel) + " U"
     }
 }

--- a/OmniBLE/PumpManagerUI/Views/OmniBLEReservoirView.swift
+++ b/OmniBLE/PumpManagerUI/Views/OmniBLEReservoirView.swift
@@ -117,27 +117,19 @@ public final class OmniBLEReservoirView: LevelHUDView, NibLoadable {
         return formatter
     }()
 
-    private let insulinFormatter: NumberFormatter = {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.maximumFractionDigits = 3
-        return formatter
-    }()
-
-
     public func update(volume: Double?, at date: Date, level: Double?, reservoirAlertState: ReservoirAlertState) {
         self.reservoirLevel = level
 
         let time = timeFormatter.string(from: date)
         caption?.text = time
 
-        if let volume = volume, volume <= Pod.maximumReservoirReading {
+        if let volume = volume, isValidReservoirLevelValue(volume) {
             if let units = numberFormatter.string(from: volume) {
                 volumeLabel.text = String(format: LocalizedString("%@U", comment: "Format string for reservoir volume. (1: The localized volume)"), units)
 
                 accessibilityValue = String(format: LocalizedString("%1$@ units remaining at %2$@", comment: "Accessibility format string for (1: localized volume)(2: time)"), units, time)
             }
-        } else if let maxReservoirReading = insulinFormatter.string(from: Pod.maximumReservoirReading) {
+        } else if let maxReservoirReading = numberFormatter.string(from: Pod.maximumReservoirReading) {
             accessibilityValue = String(format: LocalizedString("Greater than %1$@ units remaining at %2$@", comment: "Accessibility format string for (1: localized volume)(2: time)"), maxReservoirReading, time)
         }
         self.reservoirAlertState = reservoirAlertState


### PR DESCRIPTION
+ Fix calls to store() when comms were unsuccessful
+ Account for non-zero cannulaInsertionUnitsExtra in initial updates
+ Updated StatusResponse CustomDebugStringConvertible extension
+ Remove useless completionBeep options for basal enabling session funcs
+ Updated bolus timing
+ deactivatePod() cleanup
+ Add additional delivery state checking for failed setBasalSchedule
+ Updates to handle possible basal state mismatches
+ Improvements for uncertainly resolution in updateDeliveryStatus()
+ Only display DetailedStatus faultEventCode for actual pod faults
+ New convenience utility funcs for reservoirLevel checking & display
+ Rename pumpManager readPodStatus() to getDetailedStatus()
+ Improved and more consistent commenting

+ Persist inflight pending commands
+ Log unacknowledged message in device comms log
+ Add optional uncertainty resolution handling using getStatus()
+ PeripheralManager.{read,send}Message() -> {read,send}MessagePacket()