### PR TITLE
Various Omnipod message decode improvements

### DIFF
--- a/OmniBLE/OmnipodCommon/BasalDeliveryTable.swift
+++ b/OmniBLE/OmnipodCommon/BasalDeliveryTable.swift
@@ -164,8 +164,9 @@ public struct RateEntry {
             // Eros zero TB is the only case not using pulses
             return 0
         } else {
-            // Use delayBetweenPulses to compute rate, works for non-Eros near zero rates
-            return (.hours(1) / delayBetweenPulses) / Pod.pulsesPerUnit
+            // Use delayBetweenPulses to compute rate which will also work for non-Eros near zero rates.
+            // Round the rate calculation to a two digit value to avoid slightly off values for some cases.
+            return round(((.hours(1) / delayBetweenPulses) / Pod.pulsesPerUnit) * 100) / 100.0
         }
     }
     
@@ -174,8 +175,9 @@ public struct RateEntry {
             // Eros zero TB case uses fixed 30 minute rate entries
             return TimeInterval(minutes: 30)
         } else {
-            // Use delayBetweenPulses to compute duration, works for non-Eros near zero rates
-            return delayBetweenPulses * totalPulses
+            // Use delayBetweenPulses to compute duration which will also work for non-Eros near zero rates.
+            // Round to nearest second to not be slightly off of the 30 minute rate entry boundary for some cases.
+            return round(delayBetweenPulses * totalPulses)
         }
     }
     
@@ -231,6 +233,6 @@ public struct RateEntry {
 
 extension RateEntry: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return "RateEntry(rate:\(rate) duration:\(duration.stringValue))"
+        return "RateEntry(rate:\(rate), duration:\(duration.timeIntervalStr))"
     }
 }

--- a/OmniBLE/OmnipodCommon/MessageBlocks/CancelDeliveryCommand.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/CancelDeliveryCommand.swift
@@ -10,30 +10,24 @@
 import Foundation
 
 
-
 public struct CancelDeliveryCommand : NonceResyncableMessageBlock {
-    
+
     public let blockType: MessageBlockType = .cancelDelivery
-    
-    // ID1:1f00ee84 PTYPE:PDM SEQ:26 ID2:1f00ee84 B9:ac BLEN:7 MTYPE:1f05 BODY:e1f78752078196 CRC:03
-    
-    // Cancel bolus
-    // 1f 05 be1b741a 64 - 1U
-    // 1f 05 a00a1a95 64 - 1U over 1hr
-    // 1f 05 ff52f6c8 64 - 1U immediate, 1U over 1hr
-    
-    // Cancel temp basal
-    // 1f 05 f76d34c4 62 - 30U/hr
-    // 1f 05 156b93e8 62 - ?
-    // 1f 05 62723698 62 - 0%
-    // 1f 05 2933db73 62 - 03ea
-    
-    // Suspend is a Cancel delivery, followed by a configure alerts command (0x19)
-    // 1f 05 50f02312 03 191050f02312580f000f06046800001e0302
-    
-    // Deactivate pod:
+    // OFF 1  2 3 4 5  6
+    // 1F 05 NNNNNNNN AX
+
+    // Cancel bolus (with confirmation beep)
+    // 1f 05 be1b741a 64
+
+    // Cancel temp basal (with confirmation beep)
+    // 1f 05 f76d34c4 62
+
+    // Cancel all (before deactivate pod)
     // 1f 05 e1f78752 07
-    
+
+    // Cancel basal & temp basal for a suspend, followed by a configure alerts command (0x19) for alerts 5 & 6
+    // 1f 05 50f02312 03 19 10 50f02312 580f 000f 0604 6800 001e 0302
+
     public struct DeliveryType: OptionSet, Equatable {
         public let rawValue: UInt8
         
@@ -48,7 +42,23 @@ public struct CancelDeliveryCommand : NonceResyncableMessageBlock {
         public init(rawValue: UInt8) {
             self.rawValue = rawValue
         }
-        
+
+        var debugDescription: String {
+            switch self {
+            case .none:
+                return "None"
+            case .basal:
+                return "Basal"
+            case .tempBasal:
+                return "TempBasal"
+            case .all:
+                return "All"
+            case .allButBasal:
+                return "AllButBasal"
+            default:
+                return "\(self.rawValue)"
+            }
+        }
     }
     
     public let deliveryType: DeliveryType
@@ -85,6 +95,6 @@ public struct CancelDeliveryCommand : NonceResyncableMessageBlock {
 
 extension CancelDeliveryCommand: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return "CancelDeliveryCommand(nonce:\(Data(bigEndian: nonce).hexadecimalString), deliveryType:\(deliveryType), beepType:\(beepType))"
+        return "CancelDeliveryCommand(nonce:\(Data(bigEndian: nonce).hexadecimalString), deliveryType:\(deliveryType.debugDescription), beepType:\(beepType))"
     }
 }

--- a/OmniBLE/OmnipodCommon/MessageBlocks/DeactivatePodCommand.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/DeactivatePodCommand.swift
@@ -10,14 +10,13 @@
 import Foundation
 
 public struct DeactivatePodCommand : NonceResyncableMessageBlock {
-    
-    // ID1:1f00ee84 PTYPE:PDM SEQ:09 ID2:1f00ee84 B9:34 BLEN:6 MTYPE:1c04 BODY:0f7dc4058344 CRC:f1
+    // OFF 1  2 3 4 5
+    // 1C 04 NNNNNNNN
     
     public let blockType: MessageBlockType = .deactivatePod
     
     public var nonce: UInt32
     
-    // e1f78752 07 8196
     public var data: Data {
         var data = Data([
             blockType.rawValue,

--- a/OmniBLE/OmnipodCommon/MessageBlocks/DetailedStatus.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/DetailedStatus.swift
@@ -88,7 +88,7 @@ public struct DetailedStatus : PodInfo, Equatable {
         
         // For Eros, encodedData[19] (XX) byte is the same previousPodProgressStatus nibble in the VV byte on fault.
         // For Dash, encodedData[19] (XX) byte is uninitialized or unknown, so use VV byte for previousPodProgressStatus.
-        
+
         // Decode YYYY based on whether there was a pod fault
         if encodedData[8] == 0 {
             // For non-faults, YYYY contents not valid (either uninitialized data for Eros or some unknown content for Dash).
@@ -120,7 +120,7 @@ extension DetailedStatus: CustomDebugStringConvertible {
             "* lastProgrammingMessageSeqNum: \(lastProgrammingMessageSeqNum)",
             "* totalInsulinDelivered: \(totalInsulinDelivered.twoDecimals) U",
             "* reservoirLevel: \(reservoirLevelString(reservoirLevel)) U",
-            "* timeActive: \(timeActive.stringValue)",
+            "* timeActive: \(timeActive.timeIntervalStr)",
             "* unacknowledgedAlerts: \(unacknowledgedAlerts)",
             "",
             ].joined(separator: "\n")
@@ -135,7 +135,7 @@ extension DetailedStatus: CustomDebugStringConvertible {
             result += [
                 "* faultEventCode: \(faultEventCode.description)",
                 "* faultAccessingTables: \(faultAccessingTables)",
-                "* faultEventTimeSinceActivation: \(faultEventTimeSinceActivation?.stringValue ?? "NA")",
+                "* faultEventTimeSinceActivation: \(faultEventTimeSinceActivation?.timeIntervalStr ?? "NA")",
                 "* errorEventInfo: \(errorEventInfo?.description ?? "NA")",
                 "* previousPodProgressStatus: \(previousPodProgressStatus?.description ?? "NA")",
                 "* possibleFaultCallingAddress: \(possibleFaultCallingAddress != nil ? String(format: "0x%04x", possibleFaultCallingAddress!) : "NA")",
@@ -161,21 +161,21 @@ extension DetailedStatus: RawRepresentable {
 }
 
 extension TimeInterval {
-    var stringValue: String {
-        let totalSeconds = self
-        let minutes = Int(totalSeconds / 60) % 60
-        let hours = Int(totalSeconds / 3600) - (Int(self / 3600)/24 * 24)
-        let days = Int((totalSeconds / 3600) / 24)
-        var pluralFormOfDays = "days"
-        if days == 1 {
-            pluralFormOfDays = "day"
+    var timeIntervalStr: String {
+        var str: String = ""
+        let hours = UInt(self / 3600)
+        let minutes = UInt(self / 60) % 60
+        let seconds = UInt(self) % 60
+        if hours != 0 {
+            str += String(format: "%uh", hours)
         }
-        let timeComponent = String(format: "%02d:%02d", hours, minutes)
-        if days > 0 {
-            return String(format: "%d \(pluralFormOfDays) plus %@", days, timeComponent)
-        } else {
-            return timeComponent
+        if minutes != 0 || hours != 0 {
+            str += String(format: "%um", minutes)
         }
+        if seconds != 0 || str.isEmpty {
+            str += String(format: "%us", seconds)
+        }
+        return str
     }
 }
 

--- a/OmniBLE/OmnipodCommon/MessageBlocks/StatusResponse.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/StatusResponse.swift
@@ -52,9 +52,9 @@ public struct StatusResponse : MessageBlock {
         self.lastProgrammingMessageSeqNum = (encodedData[4] >> 3) & 0xf
         
         self.bolusNotDelivered = Double((Int(encodedData[4] & 0x3) << 8) | Int(encodedData[5])) / Pod.pulsesPerUnit
-        
+
         self.alerts = AlertSet(rawValue: ((encodedData[6] & 0x7f) << 1) | (encodedData[7] >> 7))
-        
+
         self.reservoirLevel = Double((Int(encodedData[8] & 0x3) << 8) + Int(encodedData[9])) / Pod.pulsesPerUnit
     }
 
@@ -95,7 +95,7 @@ public struct StatusResponse : MessageBlock {
 
 extension StatusResponse: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return "StatusResponse(deliveryStatus:\(deliveryStatus.description), progressStatus:\(podProgressStatus), timeActive:\(timeActive.stringValue), reservoirLevel:\(reservoirLevelString(reservoirLevel)), insulinDelivered:\(insulinDelivered.twoDecimals), bolusNotDelivered:\(bolusNotDelivered.twoDecimals), lastProgrammingMessageSeqNum:\(lastProgrammingMessageSeqNum), alerts:\(alerts)"
+        return "StatusResponse(deliveryStatus:\(deliveryStatus.description), progressStatus:\(podProgressStatus), timeActive:\(timeActive.timeIntervalStr), reservoirLevel:\(reservoirLevelString(reservoirLevel)), insulinDelivered:\(insulinDelivered.twoDecimals), bolusNotDelivered:\(bolusNotDelivered.twoDecimals), lastProgrammingMessageSeqNum:\(lastProgrammingMessageSeqNum), alerts:\(alerts))"
     }
 }
 

--- a/OmniBLE/OmnipodCommon/MessageBlocks/TempBasalExtraCommand.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/TempBasalExtraCommand.swift
@@ -75,6 +75,6 @@ public struct TempBasalExtraCommand : MessageBlock {
 
 extension TempBasalExtraCommand: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return "TempBasalExtraCommand(completionBeep:\(completionBeep), programReminderInterval:\(programReminderInterval.stringValue) remainingPulses:\(remainingPulses), delayUntilFirstPulse:\(delayUntilFirstPulse.stringValue), rateEntries:\(rateEntries))"
+        return "TempBasalExtraCommand(completionBeep:\(completionBeep), programReminderInterval:\(programReminderInterval.timeIntervalStr), remainingPulses:\(remainingPulses), delayUntilFirstPulse:\(delayUntilFirstPulse.timeIntervalStr), rateEntries:\(rateEntries))"
     }
 }

--- a/OmniBLETests/PodInfoTests.swift
+++ b/OmniBLETests/PodInfoTests.swift
@@ -14,17 +14,36 @@ import XCTest
 
 class PodInfoTests: XCTestCase {
     func testFullMessage() {
+        // 02DATAOFF 0  1  2  3 4  5  6 7  8  910 1112 1314 15 16 17 18 19 2021
+        // 02 16 // 02 0J 0K LLLL MM NNNN PP QQQQ RRRR SSSS TT UU VV WW 0X YYYY
+        // 02 16 // 02 0d 00 0000 00 00ab 6a 0384 03ff 0386 00 00 28 57 08 030d
         do {
             // Decode
             let infoResponse = try PodInfoResponse(encodedData: Data(hexadecimalString: "0216020d0000000000ab6a038403ff03860000285708030d0000")!)
             XCTAssertEqual(infoResponse.podInfoResponseSubType, .detailedStatus)
             let faultEvent = infoResponse.podInfo as! DetailedStatus
+            XCTAssertEqual(faultEvent.podInfoType, .detailedStatus)
+            XCTAssertEqual(faultEvent.podProgressStatus, .faultEventOccurred)
+            XCTAssertEqual(faultEvent.deliveryStatus, .suspended)
+            XCTAssertEqual(faultEvent.bolusNotDelivered, 0)
+            XCTAssertEqual(faultEvent.lastProgrammingMessageSeqNum, 0)
+            XCTAssertEqual(faultEvent.totalInsulinDelivered, 0xab * Pod.pulseSize)
+            XCTAssertEqual(faultEvent.totalInsulinDelivered, 8.55)
+            XCTAssertEqual(faultEvent.faultEventCode.faultType, .occlusionCheckAboveThreshold)
+            XCTAssertEqual(faultEvent.faultEventTimeSinceActivation, 0x384 * 60)
+            XCTAssertEqual(faultEvent.faultEventTimeSinceActivation, 54000)
+            XCTAssertEqual(faultEvent.reservoirLevel, Pod.reservoirLevelAboveThresholdMagicNumber, accuracy: 0.01)
+            XCTAssertEqual(faultEvent.timeActive, 0x386 * 60)
+            XCTAssertEqual(faultEvent.timeActive, 54120)
+            XCTAssertEqual(faultEvent.unacknowledgedAlerts, AlertSet(rawValue: 0))
             XCTAssertEqual(faultEvent.faultAccessingTables, false)
             XCTAssertEqual(faultEvent.podProgressStatus, .faultEventOccurred)
             XCTAssertEqual(faultEvent.errorEventInfo?.insulinStateTableCorruption, false)
             XCTAssertEqual(faultEvent.errorEventInfo?.occlusionType, 1)
             XCTAssertEqual(faultEvent.errorEventInfo?.immediateBolusInProgress, false)
             XCTAssertEqual(faultEvent.errorEventInfo?.podProgressStatus, .aboveFiftyUnits)
+            XCTAssertEqual(faultEvent.receiverLowGain, 0b01)
+            XCTAssertEqual(faultEvent.radioRSSI, 0x17)
         } catch (let error) {
             XCTFail("message decoding threw error: \(error)")
         }
@@ -134,7 +153,7 @@ class PodInfoTests: XCTestCase {
             XCTAssertEqual(Pod.reservoirLevelAboveThresholdMagicNumber, decoded.reservoirLevel, accuracy: 0.01)
             XCTAssertEqual(8100, decoded.timeActive)
             XCTAssertEqual(TimeInterval(minutes: 0x0087), decoded.timeActive)
-            XCTAssertEqual("02:15", decoded.timeActive.stringValue)
+            XCTAssertEqual("2h15m", decoded.timeActive.timeIntervalStr)
             XCTAssertEqual(0, decoded.unacknowledgedAlerts.rawValue)
             XCTAssertEqual(false, decoded.faultAccessingTables)
             XCTAssertNil(decoded.errorEventInfo)
@@ -208,7 +227,7 @@ class PodInfoTests: XCTestCase {
     }
 
     func testPodInfoFaultEventErrorShuttingDown() {
-        // Failed Pod after 1 day, 18+ hours of live use shortly after installing new omniloop.
+        // Failed Pod after 42+ hours of live use shortly after installing a buggy version of Loop.
         // 02DATAOFF 0  1  2  3 4  5  6 7  8  910 1112 1314 15 16 17 18 19 2021
         // 02 16 // 02 0J 0K LLLL MM NNNN PP QQQQ RRRR SSSS TT UU VV WW 0X YYYY
         // 02 16 // 02 0d 00 0000 04 07f2 86 09ff 03ff 0a02 00 00 08 23 08 0000
@@ -224,7 +243,7 @@ class PodInfoTests: XCTestCase {
             XCTAssertEqual(.basalOverInfusionPulse, decoded.faultEventCode.faultType)
             XCTAssertEqual(0, decoded.unacknowledgedAlerts.rawValue)
             XCTAssertEqual(TimeInterval(minutes: 0x09ff), decoded.faultEventTimeSinceActivation)
-            XCTAssertEqual("1 day plus 18:39", decoded.faultEventTimeSinceActivation?.stringValue)
+            XCTAssertEqual("42h39m", decoded.faultEventTimeSinceActivation?.timeIntervalStr)
             XCTAssertEqual(Pod.reservoirLevelAboveThresholdMagicNumber, decoded.reservoirLevel, accuracy: 0.01)
             XCTAssertEqual(TimeInterval(minutes: 0x0a02), decoded.timeActive)
             XCTAssertEqual(false, decoded.faultAccessingTables)
@@ -256,7 +275,7 @@ class PodInfoTests: XCTestCase {
             XCTAssertEqual(.occlusionCheckAboveThreshold, decoded.faultEventCode.faultType)
             XCTAssertEqual(0, decoded.unacknowledgedAlerts.rawValue)
             XCTAssertEqual(TimeInterval(minutes: 0x0e0c), decoded.faultEventTimeSinceActivation)
-            XCTAssertEqual("2 days plus 11:56", decoded.faultEventTimeSinceActivation?.stringValue)
+            XCTAssertEqual("59h56m", decoded.faultEventTimeSinceActivation?.timeIntervalStr)
             XCTAssertEqual(Pod.reservoirLevelAboveThresholdMagicNumber, decoded.reservoirLevel, accuracy: 0.01)
             XCTAssertEqual(TimeInterval(minutes: 0x0e14), decoded.timeActive)
             XCTAssertEqual(false, decoded.faultAccessingTables)
@@ -288,7 +307,7 @@ class PodInfoTests: XCTestCase {
             XCTAssertEqual(.occlusionCheckAboveThreshold, decoded.faultEventCode.faultType)
             XCTAssertEqual(0, decoded.unacknowledgedAlerts.rawValue)
             XCTAssertEqual(TimeInterval(minutes: 0x0268), decoded.faultEventTimeSinceActivation)
-            XCTAssertEqual("10:16", decoded.faultEventTimeSinceActivation?.stringValue)
+            XCTAssertEqual("10h16m", decoded.faultEventTimeSinceActivation?.timeIntervalStr)
             XCTAssertEqual(Pod.reservoirLevelAboveThresholdMagicNumber, decoded.reservoirLevel, accuracy: 0.01)
             XCTAssertEqual(TimeInterval(minutes: 0x026b), decoded.timeActive)
             XCTAssertEqual(false, decoded.faultAccessingTables)


### PR DESCRIPTION
+ Round RateEntry rate calculation to 2 digits
+ Round RateEntry duration calculation to nearest second
+ Add missing comma to RateEntry debugDescription
+ New timeIntervalStr TimeInterval var for pod interval debug info
+ Update some command commenting to be more consistent and useful
+ Add debugDescription for CancelDeliveryCommand DeliveryType
+ Add additional PodInfoTest checking and comments