### PR TITLE
New operation mode that suppresses all pod alerts & beeping

### DIFF
--- a/OmniBLE/OmnipodCommon/AlertSlot.swift
+++ b/OmniBLE/OmnipodCommon/AlertSlot.swift
@@ -9,9 +9,24 @@
 
 import Foundation
 
+fileprivate let defaultShutdownImminentTime = Pod.serviceDuration - Pod.endOfServiceImminentWindow
+fileprivate let defaultExpirationReminderTime = Pod.nominalPodLife - Pod.expirationAlertWindow
+fileprivate let defaultExpiredTime = Pod.nominalPodLife
+
 public enum AlertTrigger {
     case unitsRemaining(Double)
     case timeUntilAlert(TimeInterval)
+}
+
+extension AlertTrigger: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch self {
+        case .unitsRemaining(let units):
+            return "\(Int(units))U"
+        case .timeUntilAlert(let triggerTime):
+            return "triggerTime=\(triggerTime.timeIntervalStr)"
+        }
+    }
 }
 
 public enum BeepRepeat: UInt8 {
@@ -30,29 +45,48 @@ public enum BeepRepeat: UInt8 {
 public struct AlertConfiguration {
 
     let slot: AlertSlot
-    let trigger: AlertTrigger
     let active: Bool
     let duration: TimeInterval
+    let trigger: AlertTrigger
     let beepRepeat: BeepRepeat
     let beepType: BeepType
+    let silent: Bool
     let autoOffModifier: Bool
 
     static let length = 6
 
-    public init(alertType: AlertSlot, active: Bool = true, autoOffModifier: Bool = false, duration: TimeInterval, trigger: AlertTrigger, beepRepeat: BeepRepeat, beepType: BeepType) {
+    public init(alertType: AlertSlot, active: Bool = true, duration: TimeInterval = 0, trigger: AlertTrigger, beepRepeat: BeepRepeat, beepType: BeepType, silent: Bool = false, autoOffModifier: Bool = false)
+    {
         self.slot = alertType
         self.active = active
-        self.autoOffModifier = autoOffModifier
         self.duration = duration
         self.trigger = trigger
         self.beepRepeat = beepRepeat
         self.beepType = beepType
+        self.silent = silent
+        self.autoOffModifier = autoOffModifier
     }
 }
 
 extension AlertConfiguration: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return "AlertConfiguration(slot:\(slot), active:\(active), autoOffModifier:\(autoOffModifier), duration:\(duration), trigger:\(trigger), beepRepeat:\(beepRepeat), beepType:\(beepType))"
+        var str = "slot:\(slot)"
+        if !active {
+            str += ", active:\(active)"
+        }
+        if duration != 0 {
+            str += ", duration:\(duration.timeIntervalStr)"
+        }
+        str += ", trigger:\(trigger), beepRepeat:\(beepRepeat)"
+        if beepType != .noBeepNonCancel {
+            str += ", beepType:\(beepType)"
+        } else {
+            str += ", silent:\(silent)"
+        }
+        if autoOffModifier {
+            str += ", autoOffModifier:\(autoOffModifier)"
+        }
+        return "\nAlertConfiguration(\(str))"
     }
 }
 
@@ -61,54 +95,70 @@ extension AlertConfiguration: CustomDebugStringConvertible {
 public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
     public typealias RawValue = [String: Any]
 
-    // 2 hours long, time for user to start pairing process
+    // slot0AutoOff: auto-off timer; requires user input every x minutes -- NOT IMPLEMENTED
+    case autoOff(active: Bool, offset: TimeInterval, countdownDuration: TimeInterval, silent: Bool = false)
+
+    // slot1NotUsed
+    case notUsed
+
+    // slot2ShutdownImminent: 79 hour alarm (1 hour before shutdown)
+    case shutdownImminent(offset: TimeInterval, absAlertTime: TimeInterval, silent: Bool = false)
+
+    // slot3ExpirationReminder: User configurable with PDM (1-24 hours before 72 hour expiration)
+    // The PDM doesn't use a duration for this alert (presumably because it is limited to 2^9-1 minutes or 8h31m)
+    case expirationReminder(offset: TimeInterval, absAlertTime: TimeInterval, duration: TimeInterval = 0, silent: Bool = false)
+
+    // slot4LowReservoir: reservoir below configured value alert
+    case lowReservoir(units: Double, silent: Bool = false)
+
+    // slot5SuspendedReminder: pod suspended reminder, before suspendTime;
+    // short beep every 15 minutes if > 30 min, else short beep every 5 minutes
+    case podSuspendedReminder(active: Bool, offset: TimeInterval, suspendTime: TimeInterval, timePassed: TimeInterval = 0, silent: Bool = false)
+
+    // slot6SuspendTimeExpired: pod suspend time expired alarm, after suspendTime;
+    // 2 sets of beeps every min for 3 minutes repeated every 15 minutes
+    case suspendTimeExpired(offset: TimeInterval, suspendTime: TimeInterval, silent: Bool = false)
+
+    // slot7Expired: 2 hours long, time for user to start pairing process
     case waitingForPairingReminder
 
-    // 1 hour long, time for user to finish priming, cannula insertion
+    // slot7Expired: 1 hour long, time for user to finish priming, cannula insertion
     case finishSetupReminder
 
-    // User configurable with PDM (1-24 hours before 72 hour expiration) "Change Pod Soon"
-    case expirationReminder(TimeInterval)
-
-    // 72 hour alarm
-    case expired(alertTime: TimeInterval, duration: TimeInterval)
-
-    // 79 hour alarm (1 hour before shutdown)
-    case shutdownImminent(TimeInterval)
-
-    // reservoir below configured value alert
-    case lowReservoir(Double)
-
-    // auto-off timer; requires user input every x minutes
-    case autoOff(active: Bool, countdownDuration: TimeInterval)
-
-    // pod suspended reminder, before suspendTime; short beep every 15 minutes if > 30 min, else every 5 minutes
-    case podSuspendedReminder(active: Bool, suspendTime: TimeInterval)
-
-    // pod suspend time expired alarm, after suspendTime; 2 sets of beeps every min for 3 minutes repeated every 15 minutes
-    case suspendTimeExpired(suspendTime: TimeInterval)
+    // slot7Expired: 72 hour alarm
+    case expired(offset: TimeInterval, absAlertTime: TimeInterval, duration: TimeInterval, silent: Bool = false)
 
     public var description: String {
         var alertName: String
         switch self {
-        case .waitingForPairingReminder:
-            return LocalizedString("Waiting for pairing reminder", comment: "Description waiting for pairing reminder")
-        case .finishSetupReminder:
-            return LocalizedString("Finish setup reminder", comment: "Description for finish setup reminder")
-        case .expirationReminder:
-            alertName = LocalizedString("Expiration alert", comment: "Description for expiration alert")
-        case .expired:
-            alertName = LocalizedString("Expiration advisory", comment: "Description for expiration advisory")
-        case .shutdownImminent:
-            alertName = LocalizedString("Shutdown imminent", comment: "Description for shutdown imminent")
-        case .lowReservoir(let units):
-            alertName = String(format: LocalizedString("Low reservoir advisory (%1$gU)", comment: "Format string for description for low reservoir advisory (1: reminder units)"), units)
+        // slot0AutoOff
         case .autoOff:
             alertName = LocalizedString("Auto-off", comment: "Description for auto-off")
+        // slot1NotUsed
+        case .notUsed:
+            alertName = LocalizedString("Not used", comment: "Description for not used slot")
+        // slot2ShutdownImminent
+        case .shutdownImminent:
+            alertName = LocalizedString("Shutdown imminent", comment: "Description for shutdown imminent")
+        // slot3ExpirationReminder
+        case .expirationReminder:
+            alertName = LocalizedString("Expiration alert", comment: "Description for expiration alert")
+        // slot4LowReservoir
+        case .lowReservoir:
+            alertName = LocalizedString("Low reservoir advisory", comment: "Format string for description for low reservoir advisory")
+        // slot5SuspendedReminder
         case .podSuspendedReminder:
             alertName = LocalizedString("Pod suspended reminder", comment: "Description for pod suspended reminder")
+        // slot6SuspendTimeExpired
         case .suspendTimeExpired:
             alertName = LocalizedString("Suspend time expired", comment: "Description for suspend time expired")
+        // slot7Expired
+        case .waitingForPairingReminder:
+            alertName = LocalizedString("Waiting for pairing reminder", comment: "Description waiting for pairing reminder")
+        case .finishSetupReminder:
+            alertName = LocalizedString("Finish setup reminder", comment: "Description for finish setup reminder")
+        case .expired:
+            alertName = LocalizedString("Expiration advisory", comment: "Description for expiration advisory")
         }
         if self.configuration.active == false {
             alertName += LocalizedString(" (inactive)", comment: "Description for an inactive alert modifier")
@@ -118,57 +168,89 @@ public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
 
     public var configuration: AlertConfiguration {
         switch self {
-        case .waitingForPairingReminder:
-            return AlertConfiguration(alertType: .slot7, duration: .minutes(110), trigger: .timeUntilAlert(.minutes(10)), beepRepeat: .every5Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        case .finishSetupReminder:
-            return AlertConfiguration(alertType: .slot7, duration: .minutes(55), trigger: .timeUntilAlert(.minutes(5)), beepRepeat: .every5Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        case .expirationReminder(let alertTime):
-            let active = alertTime != 0 // disable if alertTime is 0
-            return AlertConfiguration(alertType: .slot3, active: active, duration: 0, trigger: .timeUntilAlert(alertTime), beepRepeat: .every1MinuteFor3MinutesAndRepeatEvery15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        case .expired(let alarmTime, let duration):
-            let active = alarmTime != 0 // disable if alarmTime is 0
-            return AlertConfiguration(alertType: .slot7, active: active, duration: duration, trigger: .timeUntilAlert(alarmTime), beepRepeat: .every60Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        case .shutdownImminent(let alarmTime):
-            let active = alarmTime != 0 // disable if alarmTime is 0
-            return AlertConfiguration(alertType: .slot2, active: active, duration: 0, trigger: .timeUntilAlert(alarmTime), beepRepeat: .every15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        case .lowReservoir(let units):
-            let active = units != 0 // disable if units is 0
-            return AlertConfiguration(alertType: .slot4, active: active, duration: 0, trigger: .unitsRemaining(units), beepRepeat: .every1MinuteFor3MinutesAndRepeatEvery60Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        case .autoOff(let active, let countdownDuration):
-            return AlertConfiguration(alertType: .slot0, active: active, autoOffModifier: true, duration: .minutes(15), trigger: .timeUntilAlert(countdownDuration), beepRepeat: .every1MinuteFor15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        case .podSuspendedReminder(let active, let suspendTime):
-            // A suspendTime of 0 is an untimed suspend
-            let reminderInterval, duration: TimeInterval
-            let trigger: AlertTrigger
-            let beepRepeat: BeepRepeat
-            let beepType: BeepType
+        // slot0AutoOff
+        case .autoOff(let active, _, let countdownDuration, let silent):
+            return AlertConfiguration(alertType: .slot0AutoOff, active: active, duration: .minutes(15), trigger: .timeUntilAlert(countdownDuration), beepRepeat: .every1MinuteFor15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: silent, autoOffModifier: true)
+
+        // slot1NotUsed
+        case .notUsed:
+            return AlertConfiguration(alertType: .slot1NotUsed, duration: .minutes(55), trigger: .timeUntilAlert(.minutes(5)), beepRepeat: .every5Minutes, beepType: .noBeepNonCancel)
+
+        // slot2ShutdownImminent
+        case .shutdownImminent(let offset, let absAlertTime, let silent):
+            let active = absAlertTime != 0 // disable if absAlertTime is 0
+            let triggerTime: TimeInterval
             if active {
-                if suspendTime >= TimeInterval(minutes :30) {
-                    // Use 15-minute pod suspended reminder beeps for longer scheduled suspend times as per PDM.
-                    reminderInterval = TimeInterval(minutes: 15)
-                    beepRepeat = .every15Minutes
-                } else {
-                    // Use 5-minute pod suspended reminder beeps for shorter scheduled suspend times.
-                    reminderInterval = TimeInterval(minutes: 5)
-                    beepRepeat = .every5Minutes
-                }
+                triggerTime = absAlertTime - offset
+            } else {
+                triggerTime = 0
+            }
+            return AlertConfiguration(alertType: .slot2ShutdownImminent, active: active, trigger: .timeUntilAlert(triggerTime), beepRepeat: .every15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: silent)
+
+        // slot3ExpirationReminder
+        case .expirationReminder(let offset, let absAlertTime, let duration, let silent):
+            let active = absAlertTime != 0 // disable if absAlertTime is 0
+            let triggerTime: TimeInterval
+            if active {
+                triggerTime = absAlertTime - offset
+            } else {
+                triggerTime = 0
+            }
+            return AlertConfiguration(alertType: .slot3ExpirationReminder, active: active, duration: duration, trigger: .timeUntilAlert(triggerTime), beepRepeat: .every1MinuteFor3MinutesAndRepeatEvery15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: silent)
+
+        // slot4LowReservoir
+        case .lowReservoir(let units, let silent):
+            let active = units != 0 // disable if units is 0
+            return AlertConfiguration(alertType: .slot4LowReservoir, active: active, trigger: .unitsRemaining(units), beepRepeat: .every1MinuteFor3MinutesAndRepeatEvery60Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: silent)
+
+        // slot5SuspendedReminder
+        // A suspendTime of 0 is an untimed suspend
+        // timePassed will be > 0 for an existing pod suspended reminder changing its silent state
+        case .podSuspendedReminder(let active, _, let suspendTime, let timePassed, let silent):
+            let reminderInterval, duration: TimeInterval
+            var beepRepeat: BeepRepeat
+            let beepType: BeepType
+            let trigger: AlertTrigger
+            var isActive: Bool = active
+
+            if suspendTime == 0 || suspendTime >= TimeInterval(minutes: 30) {
+                // Use 15-minute pod suspended reminder beeps for untimed or longer scheduled suspend times.
+                reminderInterval = TimeInterval(minutes: 15)
+                beepRepeat = .every15Minutes
+            } else {
+                // Use 5-minute pod suspended reminder beeps for shorter scheduled suspend times.
+                reminderInterval = TimeInterval(minutes: 5)
+                beepRepeat = .every5Minutes
+            }
+
+            // Make alert inactive if there isn't enough remaining in suspend time for a reminder beep.
+            let suspendTimeRemaining = suspendTime - timePassed
+            if suspendTime != 0 && suspendTimeRemaining <= reminderInterval {
+                isActive = false
+            }
+
+            if isActive {
+                // Compute the alert trigger time as the interval until the next upcoming reminder interval
+                let triggerTime: TimeInterval = .seconds(reminderInterval - Double((Int(timePassed) % Int(reminderInterval))))
+
                 if suspendTime == 0 {
                     duration = 0 // Untimed suspend, no duration
-                } else if suspendTime > reminderInterval {
-                    duration = suspendTime - reminderInterval // End after suspendTime total time
                 } else {
-                    duration = .minutes(1) // Degenerate case, end ASAP
+                    // duration is from triggerTime to suspend time remaining
+                    duration = suspendTimeRemaining - triggerTime
                 }
-                trigger = .timeUntilAlert(reminderInterval) // Start after reminderInterval has passed
+                trigger = .timeUntilAlert(triggerTime) // time to next reminder interval with the suspend time
                 beepType = .beep
             } else {
+                beepRepeat = .once
                 duration = 0
                 trigger = .timeUntilAlert(.minutes(0))
-                beepRepeat = .once
                 beepType = .noBeepCancel
             }
-            return AlertConfiguration(alertType: .slot5, active: active, duration: duration, trigger: trigger, beepRepeat: beepRepeat, beepType: beepType)
-        case .suspendTimeExpired(let suspendTime):
+            return AlertConfiguration(alertType: .slot5SuspendedReminder, active: isActive, duration: duration, trigger: trigger, beepRepeat: beepRepeat, beepType: beepType, silent: silent)
+
+        // slot6SuspendTimeExpired
+        case .suspendTimeExpired(_, let suspendTime, let silent):
             let active = suspendTime != 0 // disable if suspendTime is 0
             let trigger: AlertTrigger
             let beepRepeat: BeepRepeat
@@ -182,7 +264,29 @@ public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
                 beepRepeat = .once
                 beepType = .noBeepCancel
             }
-            return AlertConfiguration(alertType: .slot6, active: active, duration: 0, trigger: trigger, beepRepeat: beepRepeat, beepType: beepType)
+            return AlertConfiguration(alertType: .slot6SuspendTimeExpired, active: active, trigger: trigger, beepRepeat: beepRepeat, beepType: beepType, silent: silent)
+
+        // slot7Expired
+        case .waitingForPairingReminder:
+            // After pod is powered up, beep every 10 minutes for up to 2 hours before pairing before failing
+            let totalDuration: TimeInterval = .hours(2)
+            let startOffset: TimeInterval = .minutes(10)
+            return AlertConfiguration(alertType: .slot7Expired, duration: totalDuration - startOffset, trigger: .timeUntilAlert(startOffset), beepRepeat: .every5Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
+        case .finishSetupReminder:
+            // After pod is paired, beep every 5 minutes for up to 1 hour for pod setup to complete before failing
+            let totalDuration: TimeInterval = .hours(1)
+            let startOffset: TimeInterval = .minutes(5)
+            return AlertConfiguration(alertType: .slot7Expired, duration: totalDuration - startOffset, trigger: .timeUntilAlert(startOffset), beepRepeat: .every5Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
+        case .expired(let offset, let absAlertTime, let duration, let silent):
+            // Normally used to alert at Pod.nominalPodLife (72 hours) for Pod.expirationAdvisoryWindow (7 hours)
+            let active = absAlertTime != 0 // disable if absAlertTime is 0
+            let triggerTime: TimeInterval
+            if active {
+                triggerTime = absAlertTime - offset
+            } else {
+                triggerTime = .minutes(0)
+            }
+            return AlertConfiguration(alertType: .slot7Expired, active: active, duration: duration, trigger: .timeUntilAlert(triggerTime), beepRepeat: .every60Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: silent)
         }
     }
 
@@ -195,51 +299,92 @@ public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
         }
 
         switch name {
-        case "waitingForPairingReminder":
-            self = .waitingForPairingReminder
-        case "finishSetupReminder":
-            self = .finishSetupReminder
-        case "expirationReminder":
-            guard let alertTime = rawValue["alertTime"] as? Double else {
-                return nil
-            }
-            self = .expirationReminder(TimeInterval(alertTime))
-        case "expired":
-            guard let alarmTime = rawValue["alarmTime"] as? Double,
-                let duration = rawValue["duration"] as? Double else
+        case "autoOff":
+            guard let active = rawValue["active"] as? Bool,
+                let countdownDuration = rawValue["countdownDuration"] as? TimeInterval else
             {
                 return nil
             }
-            self = .expired(alertTime: TimeInterval(alarmTime), duration: TimeInterval(duration))
+            let offset = rawValue["offset"] as? TimeInterval ?? 0
+            let silent = rawValue["silent"] as? Bool ?? false
+            self = .autoOff(active: active, offset: offset, countdownDuration: countdownDuration, silent: silent)
         case "shutdownImminent":
-            guard let alarmTime = rawValue["alarmTime"] as? Double else {
+            guard let alarmTime = rawValue["alarmTime"] as? TimeInterval else {
                 return nil
             }
-            self = .shutdownImminent(alarmTime)
+            let offset = rawValue["offset"] as? TimeInterval ?? 0
+            let offsetToUse, absAlertTime: TimeInterval
+            if offset == 0 {
+                // use default values as no offset value was found
+                absAlertTime = defaultShutdownImminentTime
+                offsetToUse = absAlertTime - alarmTime
+            } else {
+                absAlertTime = offset + alarmTime
+                offsetToUse = offset
+            }
+            let silent = rawValue["silent"] as? Bool ?? false
+            self = .shutdownImminent(offset: offsetToUse, absAlertTime: absAlertTime, silent: silent)
+        case "expirationReminder":
+            guard let alertTime = rawValue["alertTime"] as? TimeInterval else {
+                return nil
+            }
+            let offset = rawValue["offset"] as? TimeInterval ?? 0
+            let offsetToUse, absAlertTime: TimeInterval
+            if offset == 0 {
+                // use default values as no offset value was found
+                absAlertTime = defaultExpirationReminderTime
+                offsetToUse = absAlertTime - alertTime
+            } else {
+                absAlertTime = offset + alertTime
+                offsetToUse = offset
+            }
+            let duration = rawValue["duration"] as? TimeInterval ?? 0
+            let silent = rawValue["silent"] as? Bool ?? false
+            self = .expirationReminder(offset: offsetToUse, absAlertTime: absAlertTime, duration: duration,  silent: silent)
         case "lowReservoir":
             guard let units = rawValue["units"] as? Double else {
                 return nil
             }
-            self = .lowReservoir(units)
-        case "autoOff":
-            guard let active = rawValue["active"] as? Bool,
-                let countdownDuration = rawValue["countdownDuration"] as? Double else
-            {
-                return nil
-            }
-            self = .autoOff(active: active, countdownDuration: TimeInterval(countdownDuration))
+            let silent = rawValue["silent"] as? Bool ?? false
+            self = .lowReservoir(units: units, silent: silent)
         case "podSuspendedReminder":
             guard let active = rawValue["active"] as? Bool,
-                let suspendTime = rawValue["suspendTime"] as? Double else
+                let suspendTime = rawValue["suspendTime"] as? TimeInterval else
             {
                 return nil
             }
-            self = .podSuspendedReminder(active: active, suspendTime: suspendTime)
+            let offset = rawValue["offset"] as? TimeInterval ?? 0
+            let silent = rawValue["silent"] as? Bool ?? false
+            self = .podSuspendedReminder(active: active, offset: offset, suspendTime: suspendTime, silent: silent)
         case "suspendTimeExpired":
             guard let suspendTime = rawValue["suspendTime"] as? Double else {
                 return nil
             }
-            self = .suspendTimeExpired(suspendTime: suspendTime)
+            let offset = rawValue["offset"] as? TimeInterval ?? 0
+            let silent = rawValue["silent"] as? Bool ?? false
+            self = .suspendTimeExpired(offset: offset, suspendTime: suspendTime, silent: silent)
+        case "waitingForPairingReminder":
+            self = .waitingForPairingReminder
+        case "finishSetupReminder":
+            self = .finishSetupReminder
+        case "expired":
+            guard let alarmTime = rawValue["alarmTime"] as? TimeInterval,
+                let duration = rawValue["duration"] as? TimeInterval else
+            {
+                return nil
+            }
+            let offset = rawValue["offset"] as? TimeInterval ?? 0
+            let offsetToUse, absAlertTime: TimeInterval
+            if offset == 0 {
+                // use default values as no offset value was found
+                absAlertTime = defaultExpiredTime
+                offsetToUse = absAlertTime - alarmTime
+            } else {
+                absAlertTime = offset + alarmTime
+                offsetToUse = offset
+            }
+            let silent = rawValue["silent"] as? Bool ?? false
+            self = .expired(offset: offsetToUse, absAlertTime: absAlertTime, duration: duration, silent: silent)
         default:
             return nil
         }
@@ -249,50 +394,65 @@ public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
 
         let name: String = {
             switch self {
-            case .waitingForPairingReminder:
-                return "waitingForPairingReminder"
-            case .finishSetupReminder:
-                return "finishSetupReminder"
-            case .expirationReminder:
-                return "expirationReminder"
-            case .expired:
-                return "expired"
-            case .shutdownImminent:
-                return "shutdownImminent"
-            case .lowReservoir:
-                return "lowReservoir"
             case .autoOff:
                 return "autoOff"
+            case .notUsed:
+                return "notUsed"
+            case .shutdownImminent:
+                return "shutdownImminent"
+            case .expirationReminder:
+                return "expirationReminder"
+            case .lowReservoir:
+                return "lowReservoir"
             case .podSuspendedReminder:
                 return "podSuspendedReminder"
             case .suspendTimeExpired:
                 return "suspendTimeExpired"
+            case .waitingForPairingReminder:
+                return "waitingForPairingReminder"
+            case .finishSetupReminder:
+                return "finishSetupReminder"
+            case .expired:
+                return "expired"
             }
         }()
-
 
         var rawValue: RawValue = [
             "name": name,
         ]
 
         switch self {
-        case .expirationReminder(let alertTime):
-            rawValue["alertTime"] = alertTime
-        case .expired(let alarmTime, let duration):
-            rawValue["alarmTime"] = alarmTime
-            rawValue["duration"] = duration
-        case .shutdownImminent(let alarmTime):
-            rawValue["alarmTime"] = alarmTime
-        case .lowReservoir(let units):
-            rawValue["units"] = units
-        case .autoOff(let active, let countdownDuration):
+        case .autoOff(let active, let offset, let countdownDuration, let silent):
             rawValue["active"] = active
+            rawValue["offset"] = offset
             rawValue["countdownDuration"] = countdownDuration
-        case .podSuspendedReminder(let active, let suspendTime):
+            rawValue["silent"] = silent
+        case .shutdownImminent(let offset, let absAlertTime, let silent):
+            rawValue["offset"] = offset
+            rawValue["alarmTime"] = absAlertTime - offset
+            rawValue["silent"] = silent
+        case .expirationReminder(let offset, let absAlertTime, let duration, let silent):
+            rawValue["offset"] = offset
+            rawValue["alertTime"] = absAlertTime - offset
+            rawValue["duration"] = duration
+            rawValue["silent"] = silent
+        case .lowReservoir(let units, let silent):
+            rawValue["units"] = units
+            rawValue["silent"] = silent
+        case .podSuspendedReminder(let active, let offset, let suspendTime, _, let silent):
             rawValue["active"] = active
+            rawValue["offset"] = offset
             rawValue["suspendTime"] = suspendTime
-        case .suspendTimeExpired(let suspendTime):
+            rawValue["silent"] = silent
+        case .suspendTimeExpired(let offset, let suspendTime, let silent):
+            rawValue["offset"] = offset
             rawValue["suspendTime"] = suspendTime
+            rawValue["silent"] = silent
+        case .expired(let offset, let absAlertTime, let duration, let silent):
+            rawValue["offset"] = offset
+            rawValue["alarmTime"] = absAlertTime - offset
+            rawValue["duration"] = duration
+            rawValue["silent"] = silent
         default:
             break
         }
@@ -302,14 +462,14 @@ public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
 }
 
 public enum AlertSlot: UInt8 {
-    case slot0 = 0x00
-    case slot1 = 0x01
-    case slot2 = 0x02
-    case slot3 = 0x03
-    case slot4 = 0x04
-    case slot5 = 0x05
-    case slot6 = 0x06
-    case slot7 = 0x07
+    case slot0AutoOff = 0x00
+    case slot1NotUsed = 0x01
+    case slot2ShutdownImminent = 0x02
+    case slot3ExpirationReminder = 0x03
+    case slot4LowReservoir = 0x04
+    case slot5SuspendedReminder = 0x05
+    case slot6SuspendTimeExpired = 0x06
+    case slot7Expired = 0x07
 
     public var bitMaskValue: UInt8 {
         return 1<<rawValue
@@ -374,9 +534,125 @@ public struct AlertSet: RawRepresentable, Collection, CustomStringConvertible, E
 
 // Returns true if there are any active suspend related alerts
 public func hasActiveSuspendAlert(configuredAlerts: [AlertSlot : PodAlert]) -> Bool {
-    // slot5 is for podSuspendedReminder and slot6 is for suspendTimeExpired
-    if configuredAlerts.contains(where: { ($0.key == .slot5 || $0.key == .slot6) && $0.value.configuration.active }) {
+    if configuredAlerts.contains(where: { ($0.key == .slot5SuspendedReminder || $0.key == .slot6SuspendTimeExpired) && $0.value.configuration.active })
+    {
         return true
     }
     return false
+}
+
+// Returns a descriptive string for alerts set in alerts
+public func alertString(alerts: AlertSet) -> String {
+
+    if alerts.isEmpty {
+        return String(describing: alerts)
+    }
+
+    let alertDescription = alerts.map { (slot) -> String in
+        switch slot {
+        case .slot0AutoOff:
+            return PodAlert.autoOff(active: true, offset: 0, countdownDuration: 0).description
+        case .slot1NotUsed:
+            return PodAlert.notUsed.description
+        case .slot2ShutdownImminent:
+            return PodAlert.shutdownImminent(offset: 0, absAlertTime: defaultShutdownImminentTime).description
+        case .slot3ExpirationReminder:
+            return PodAlert.expirationReminder(offset: 0, absAlertTime: defaultExpirationReminderTime).description
+        case .slot4LowReservoir:
+            return PodAlert.lowReservoir(units: 1).description
+        case .slot5SuspendedReminder:
+            return PodAlert.podSuspendedReminder(active: true, offset: 0, suspendTime: .minutes(30)).description
+        case .slot6SuspendTimeExpired:
+            return PodAlert.suspendTimeExpired(offset: 0, suspendTime: 1).description
+        case .slot7Expired:
+            return PodAlert.expired(offset: 0, absAlertTime: defaultExpiredTime, duration: Pod.expirationAdvisoryWindow).description
+        }
+    }
+
+    return alertDescription.joined(separator: ", ")
+}
+
+// Returns a proper set of PodAlerts based on the pod timeActive and silent boolean
+// for all the configuredAlerts that are still active and not expired
+func createPodAlerts(configuredAlerts: [AlertSlot: PodAlert], timeActive: TimeInterval, silent: Bool) -> [PodAlert] {
+
+    var podAlerts: [PodAlert] = []
+
+    for alert in configuredAlerts {
+        // Just skip this alert if not previously active
+        guard alert.value.configuration.active else {
+            continue
+        }
+
+        // Map alerts to corresponding appropriate new ones at the current pod time using the specified silent value.
+        switch alert.value {
+
+        case .shutdownImminent(let offset, let alertTime, _):
+            // alertTime is absolute when offset is non-zero, otherwise use  default value
+            var absAlertTime = offset != 0 ? alertTime : defaultShutdownImminentTime
+            if timeActive >= absAlertTime {
+                // alert trigger is not in the future, make inactive using a 0 value
+                absAlertTime = 0
+            }
+            // create new shutdownImminent podAlert using the current timeActive and the original absolute alert time
+            podAlerts.append(PodAlert.shutdownImminent(offset: timeActive, absAlertTime: absAlertTime, silent: silent))
+
+        case .expirationReminder(let offset, let alertTime, let alertDuration, _):
+            let duration: TimeInterval
+
+            // alertTime is absolute when offset is non-zero, otherwise use default value
+            var absAlertTime = offset != 0 ? alertTime : defaultExpirationReminderTime
+            if timeActive >= absAlertTime {
+                // alert trigger is not in the future, make inactive using a 0 value
+                absAlertTime = 0
+                duration = 0
+            } else {
+                duration = alertDuration
+            }
+            // create new expirationReminder podAlert using the current active time and the original absolute alert time and duration
+            podAlerts.append(PodAlert.expirationReminder(offset: timeActive, absAlertTime: absAlertTime, duration: duration, silent: silent))
+
+        case .lowReservoir(let units, _):
+            // trivial with no time trigger issues to worry about
+            podAlerts.append(PodAlert.lowReservoir(units: units, silent: silent))
+
+        case .podSuspendedReminder(let active, let offset, let suspendTime, _, _):
+            let timePassed: TimeInterval = max(timeActive - offset, .hours(2))
+            // Pass along the computed time passed since alert was originally set so creation routine can
+            // do all the grunt work dealing with varying reminder intervals and time passing scenarios.
+            podAlerts.append(PodAlert.podSuspendedReminder(active: active, offset: offset, suspendTime: suspendTime, timePassed: timePassed, silent: silent))
+
+        case .suspendTimeExpired(let lastOffset, let lastSuspendTime, _):
+            let absAlertTime = lastOffset + lastSuspendTime
+            let suspendTime: TimeInterval
+            if timeActive >= absAlertTime {
+                // alert trigger is not in the future, make inactive using a 0 value
+                suspendTime = 0
+            } else {
+                // recompute a new suspendTime based on the current pod time
+                suspendTime = absAlertTime - timeActive
+            }
+            // create a new suspendTimeExpired PodAlert using the current active time and remaining suspend time (if any)
+            podAlerts.append(PodAlert.suspendTimeExpired(offset: timeActive, suspendTime: suspendTime, silent: silent))
+
+        case .expired(let offset, let alertTime, let alertDuration, _):
+            let duration: TimeInterval
+
+            // alertTime is absolute when offset is non-zero, otherwise use default value
+            var absAlertTime = offset != 0 ? alertTime : defaultExpiredTime
+            if timeActive >= absAlertTime {
+                // alert trigger is not in the future, make inactive using a 0 value
+                absAlertTime = 0
+                duration = 0
+            } else {
+                duration = alertDuration
+            }
+            // create new expired podAlert using the current active time and the original absolute alert time and duration
+            podAlerts.append(PodAlert.expired(offset: timeActive, absAlertTime: absAlertTime, duration: duration, silent: silent))
+
+        default:
+            break
+        }
+    }
+    return podAlerts
 }

--- a/OmniBLE/OmnipodCommon/MessageBlocks/ConfigureAlertsCommand.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/ConfigureAlertsCommand.swift
@@ -22,7 +22,9 @@ public struct ConfigureAlertsCommand : NonceResyncableMessageBlock {
             UInt8(4 + configurations.count * AlertConfiguration.length),
             ])
         data.appendBigEndian(nonce)
-        for config in configurations {
+        // Sorting the alerts not required, but it can be helpful for log analysis
+        let sorted = configurations.sorted { $0.slot.rawValue < $1.slot.rawValue }
+        for config in sorted {
             data.append(contentsOf: config.data)
         }
         return data
@@ -93,6 +95,7 @@ extension AlertConfiguration {
         }
         self.beepType = beepType
 
+        self.silent = (beepType == .noBeepNonCancel)
     }
 
     public var data: Data {
@@ -105,12 +108,16 @@ extension AlertConfiguration {
         if autoOffModifier {
             firstByte += 1 << 1
         }
+
+        // The 9-bit duration is limited to 2^9-1 minutes max value
+        let durationMinutes = min(UInt(duration.minutes), 0x1ff)
+
         // High bit of duration
-        firstByte += UInt8((Int(duration.minutes) >> 8) & 0x1)
+        firstByte += UInt8((durationMinutes >> 8) & 0x1)
 
         var data = Data([
             firstByte,
-            UInt8(Int(duration.minutes) & 0xff)
+            UInt8(durationMinutes & 0xff)
             ])
 
         switch trigger {
@@ -123,7 +130,8 @@ extension AlertConfiguration {
             data.appendBigEndian(minutes)
         }
         data.append(beepRepeat.rawValue)
-        data.append(beepType.rawValue)
+        let beepTypeToSet: BeepType = silent ? .noBeepNonCancel : beepType
+        data.append(beepTypeToSet.rawValue)
 
         return data
     }

--- a/OmniBLE/PumpManager/OmniBLEPumpManagerState.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManagerState.swift
@@ -25,6 +25,8 @@ public struct OmniBLEPumpManagerState: RawRepresentable, Equatable {
 
     public var expirationReminderDate: Date?
 
+    public var silencePod: Bool
+
     public var confirmationBeeps: Bool
 
     public var extendedBeeps: Bool
@@ -56,6 +58,7 @@ public struct OmniBLEPumpManagerState: RawRepresentable, Equatable {
         self.timeZone = timeZone
         self.basalSchedule = basalSchedule
         self.unstoredDoses = []
+        self.silencePod = false
         self.confirmationBeeps = false
         self.extendedBeeps = false
         if controllerId != nil && podId != nil {
@@ -139,6 +142,8 @@ public struct OmniBLEPumpManagerState: RawRepresentable, Equatable {
             self.unstoredDoses = []
         }
 
+        self.silencePod = rawValue["silencePod"] as? Bool ?? false
+
         self.confirmationBeeps = rawValue["confirmationBeeps"] as? Bool ?? false
 
         self.extendedBeeps = rawValue["extendedBeeps"] as? Bool ?? rawValue["automaticBolusBeeps"] as? Bool ?? false
@@ -150,6 +155,7 @@ public struct OmniBLEPumpManagerState: RawRepresentable, Equatable {
             "timeZone": timeZone.secondsFromGMT(),
             "basalSchedule": basalSchedule.rawValue,
             "unstoredDoses": unstoredDoses.map { $0.rawValue },
+            "silencePod": silencePod,
             "confirmationBeeps": confirmationBeeps,
             "extendedBeeps": extendedBeeps,
         ]
@@ -193,6 +199,7 @@ extension OmniBLEPumpManagerState: CustomDebugStringConvertible {
             "* tempBasalEngageState: \(String(describing: tempBasalEngageState))",
             "* lastPumpDataReportDate: \(String(describing: lastPumpDataReportDate))",
             "* isPumpDataStale: \(String(describing: isPumpDataStale))",
+            "* silencePod: \(String(describing: silencePod))",
             "* confirmationBeeps: \(String(describing: confirmationBeeps))",
             "* extendedBeeps: \(String(describing: extendedBeeps))",
             "* controllerId: \(String(format: "%08X", controllerId))",

--- a/OmniBLE/PumpManagerUI/OmniBLEHUDProvider.swift
+++ b/OmniBLE/PumpManagerUI/OmniBLEHUDProvider.swift
@@ -76,8 +76,9 @@ internal class OmniBLEHUDProvider: NSObject, HUDProvider, PodStateObserver {
             let reservoirLevel = reservoirVolume?.asReservoirPercentage()
 
             var reservoirAlertState: ReservoirAlertState = .ok
-            for (_, alert) in podState.activeAlerts {
-                if case .lowReservoir = alert {
+            let activeAlerts = podState.activeAlertSlots
+            for i in activeAlerts.startIndex..<activeAlerts.endIndex {
+                if activeAlerts[i] == .slot4LowReservoir {
                     reservoirAlertState = .lowReservoir
                     break
                 }
@@ -156,7 +157,7 @@ internal class OmniBLEHUDProvider: NSObject, HUDProvider, PodStateObserver {
                 lifetime = 0
             }
             rawValue["lifetime"] = lifetime
-            rawValue["alerts"] = podState.activeAlerts.values.map { $0.rawValue }
+            rawValue["alerts"] = alertString(alerts: podState.activeAlertSlots)
         }
         
         if let lastInsulinMeasurements = podState?.lastInsulinMeasurements {

--- a/OmniBLE/PumpManagerUI/ViewControllers/CommandResponseViewController.swift
+++ b/OmniBLE/PumpManagerUI/ViewControllers/CommandResponseViewController.swift
@@ -44,7 +44,7 @@ extension CommandResponseViewController {
         }
     }
     
-    private static func podStatusString(status: DetailedStatus, configuredAlerts: [AlertSlot: PodAlert]) -> String {
+    private static func podStatusString(status: DetailedStatus) -> String {
         var result, str: String
 
         let formatter = DateComponentsFormatter()
@@ -56,7 +56,7 @@ extension CommandResponseViewController {
         } else {
             str = String(format: LocalizedString("%1$@ minutes", comment: "The format string for minutes (1: number of minutes string)"), String(describing: Int(status.timeActive / 60)))
         }
-        result = String(format: LocalizedString("Pod Active Clock: %1$@\n", comment: "The format string for Pod Active Clock: (1: formatted time)"), str)
+        result = String(format: LocalizedString("Pod Active: %1$@\n", comment: "The format string for Pod Active: (1: formatted time)"), str)
 
         result += String(format: LocalizedString("Delivery Status: %1$@\n", comment: "The format string for Delivery Status: (1: delivery status string)"), String(describing: status.deliveryStatus))
 
@@ -66,19 +66,7 @@ extension CommandResponseViewController {
 
         result += String(format: LocalizedString("Last Bolus Not Delivered: %1$@ U\n", comment: "The format string for Last Bolus Not Delivered: (1: bolus not delivered string)"), status.bolusNotDelivered.twoDecimals)
 
-        let alertsDescription = status.unacknowledgedAlerts.map { (slot) -> String in
-            if let podAlert = configuredAlerts[slot] {
-                return String(describing: podAlert)
-            } else {
-                return String(describing: slot)
-            }
-        }
-        let alertString: String
-        if status.unacknowledgedAlerts.isEmpty {
-            alertString = String(describing: status.unacknowledgedAlerts)
-        } else {
-            alertString = alertsDescription.joined(separator: ", ")
-        }
+        let alertString = alertString(alerts: status.unacknowledgedAlerts)
         result += String(format: LocalizedString("Alerts: %1$@\n", comment: "The format string for Alerts: (1: the alerts string)"), alertString)
 
         if status.radioRSSI != 0 {
@@ -110,8 +98,7 @@ extension CommandResponseViewController {
                 DispatchQueue.main.async {
                     switch result {
                     case .success(let status):
-                        let configuredAlerts = pumpManager.state.podState!.configuredAlerts
-                        completionHandler(podStatusString(status: status, configuredAlerts: configuredAlerts))
+                        completionHandler(podStatusString(status: status))
                     case .failure(let error):
                         completionHandler(resultString(error: error))
                     }

--- a/OmniBLE/PumpManagerUI/ViewControllers/OmniBLESettingsViewController.swift
+++ b/OmniBLE/PumpManagerUI/ViewControllers/OmniBLESettingsViewController.swift
@@ -11,6 +11,23 @@ import UIKit
 import LoopKit
 import LoopKitUI
 
+fileprivate var defaultSuspendTime = TimeInterval(minutes: 30)
+
+public class SilencePodTableViewCell: TextButtonTableViewCell {
+
+    public func updateTextLabel(enabled: Bool) {
+        if enabled {
+            self.textLabel?.text = LocalizedString("Unsilence Pod", comment: "Title text for button to unsilence pod")
+        } else {
+            self.textLabel?.text = LocalizedString("Silence Pod", comment: "Title text for button to silence pod")
+        }
+    }
+
+    override public func loadingStatusChanged() {
+        self.isEnabled = !isLoading
+    }
+}
+
 public class ConfirmationBeepsTableViewCell: TextButtonTableViewCell {
 
     public func updateTextLabel(enabled: Bool) {
@@ -78,16 +95,28 @@ class OmniBLESettingsViewController: UITableViewController {
         return cell
     }()
 
+    lazy var silencePodTableViewCell: SilencePodTableViewCell = {
+        let cell = SilencePodTableViewCell(style: .default, reuseIdentifier: nil)
+        cell.updateTextLabel(enabled: pumpManager.silencePod)
+        return cell
+    }()
+
     lazy var confirmationBeepsTableViewCell: ConfirmationBeepsTableViewCell = {
         let cell = ConfirmationBeepsTableViewCell(style: .default, reuseIdentifier: nil)
         cell.updateTextLabel(enabled: pumpManager.confirmationBeeps)
+        cell.isEnabled = !pumpManager.silencePod
         return cell
     }()
     
     lazy var extendedBeepsTableViewCell: ExtendedBeepsTableViewCell = {
         let cell = ExtendedBeepsTableViewCell(style: .default, reuseIdentifier: nil)
         cell.updateTextLabel(enabled: pumpManager.extendedBeeps)
-        cell.isEnabled = self.pumpManager.confirmationBeeps
+        cell.isEnabled = pumpManager.confirmationBeeps && !pumpManager.silencePod
+        return cell
+    }()
+
+    lazy var expirationReminderDateTableViewCell: ExpirationReminderDateTableViewCell = {
+        let cell = ExpirationReminderDateTableViewCell(style: .default, reuseIdentifier: nil)
         return cell
     }()
 
@@ -275,6 +304,7 @@ class OmniBLESettingsViewController: UITableViewController {
     
     private enum ConfigurationRow: Int, CaseIterable {
         case suspendResume = 0
+        case silencePod
         case enableDisableConfirmationBeeps
         case enableDisableExtendedBeeps
         case reminder
@@ -284,7 +314,7 @@ class OmniBLESettingsViewController: UITableViewController {
     
     fileprivate enum StatusRow: Int, CaseIterable {
         case expiresAt = 0
-        case podActiveClock
+        case podActive
         case bolus
         case basal
         case alarms
@@ -343,7 +373,7 @@ class OmniBLESettingsViewController: UITableViewController {
             if statusRow == .alarms {
                 let cell = tableView.dequeueReusableCell(withIdentifier: NSStringFromClass(AlarmsTableViewCell.self), for: indexPath) as! AlarmsTableViewCell
                 cell.textLabel?.text = LocalizedString("Alarms", comment: "The title of the cell showing alarm status")
-                cell.alerts = podState.activeAlerts
+                cell.alerts = podState.activeAlertSlots
                 return cell
             }
             let cell = tableView.dequeueReusableCell(withIdentifier: NSStringFromClass(SettingsTableViewCell.self), for: indexPath)
@@ -360,10 +390,10 @@ class OmniBLESettingsViewController: UITableViewController {
                 }
                 cell.setDetailDate(podState.expiresAt, formatter: dateFormatter)
                 return cell
-            case .podActiveClock:
+            case .podActive:
                 let cell = tableView.dequeueReusableCell(withIdentifier: NSStringFromClass(SettingsTableViewCell.self), for: indexPath)
-                cell.textLabel?.text = LocalizedString("Pod Active Clock", comment: "The title of the cell showing the pod active clock")
-                cell.setDetailAge(podState.expiresAt?.addingTimeInterval(-Pod.nominalPodLife).timeIntervalSinceNow)
+                cell.textLabel?.text = LocalizedString("Pod Active", comment: "The title of the cell showing pod active time")
+                cell.setDetailAge(self.pumpManager.timeActive)
                 return cell
             case .bolus:
                 cell.textLabel?.text = LocalizedString("Bolus Delivery", comment: "The title of the cell showing pod bolus status")
@@ -400,6 +430,8 @@ class OmniBLESettingsViewController: UITableViewController {
             switch configurationRows[indexPath.row] {
             case .suspendResume:
                 return suspendResumeTableViewCell
+            case .silencePod:
+                return silencePodTableViewCell
             case .enableDisableConfirmationBeeps:
                 return confirmationBeepsTableViewCell
             case .enableDisableExtendedBeeps:
@@ -551,7 +583,7 @@ class OmniBLESettingsViewController: UITableViewController {
             switch StatusRow(rawValue: indexPath.row)! {
             case .alarms:
                 if let cell = tableView.cellForRow(at: indexPath) as? AlarmsTableViewCell {
-                    let activeSlots = AlertSet(slots: Array(cell.alerts.keys))
+                    let activeSlots = cell.alerts
                     if activeSlots.count > 0 {
                         cell.isLoading = true
                         cell.isEnabled = false
@@ -574,6 +606,9 @@ class OmniBLESettingsViewController: UITableViewController {
             switch configurationRows[indexPath.row] {
             case .suspendResume:
                 suspendResumeTapped()
+                tableView.deselectRow(at: indexPath, animated: true)
+            case .silencePod:
+                silencePodTapped()
                 tableView.deselectRow(at: indexPath, animated: true)
             case .enableDisableConfirmationBeeps:
                 confirmationBeepsTapped()
@@ -648,7 +683,7 @@ class OmniBLESettingsViewController: UITableViewController {
             switch configurationRows[indexPath.row] {
             case .reminder, .suspendResume:
                 break
-            case .enableDisableConfirmationBeeps, .enableDisableExtendedBeeps, .timeZoneOffset, .replacePod:
+            case .silencePod, .enableDisableConfirmationBeeps, .enableDisableExtendedBeeps, .timeZoneOffset, .replacePod:
                 tableView.reloadRows(at: [indexPath], with: .fade)
             }
         case .diagnostics:
@@ -672,7 +707,7 @@ class OmniBLESettingsViewController: UITableViewController {
                 }
             }
         case .suspend:
-            let suspendTime: TimeInterval = .minutes(0) // untimed suspend with reminder beeps pending UI work
+            let suspendTime = defaultSuspendTime // XXX should update the UI to make suspend time user selectable
             pumpManager.suspendDelivery(withSuspendReminders: suspendTime) { (error) in
                 if let error = error {
                     DispatchQueue.main.async {
@@ -684,13 +719,61 @@ class OmniBLESettingsViewController: UITableViewController {
         }
     }
 
+    private func setExpirationReminderDate(expirationReminderDate: Date) {
+        func done() {
+            //DispatchQueue.main.async { [weak self] in
+            //    if let self = self {
+            //        self.expirationReminderDateTableViewCell.isLoading = false
+            //    }
+            //}
+        }
+
+        pumpManager.updateExpirationReminder(expirationReminderDate, completion: { (error) in
+            if let error = error {
+                DispatchQueue.main.async {
+                    let title = LocalizedString("Error programming expiration reminder", comment: "The alert title for programming expiration reminder error")
+                    self.present(UIAlertController(with: error, title: title), animated: true)
+                }
+            }
+            done()
+        })
+    }
+
+    private func silencePodTapped() {
+        func done() {
+            DispatchQueue.main.async { [weak self] in
+                if let self = self {
+                    let podSilenced = self.pumpManager.silencePod
+                    self.silencePodTableViewCell.updateTextLabel(enabled: podSilenced)
+                    self.silencePodTableViewCell.isLoading = false
+                    self.confirmationBeepsTableViewCell.isEnabled = !podSilenced
+                    self.extendedBeepsTableViewCell.isEnabled = !podSilenced
+                }
+            }
+        }
+
+        silencePodTableViewCell.isLoading = true
+        let silencePod = !pumpManager.silencePod
+        pumpManager.setSilencePod(silencePod: silencePod, completion: { (error) in
+            if let error = error {
+                DispatchQueue.main.async {
+                    let title = LocalizedString("Error programming silence pod", comment: "The alert title for programming silence pod")
+                    self.present(UIAlertController(with: error, title: title), animated: true)
+                }
+            }
+            done()
+        })
+    }
+
     private func setConfirmationBeeps(confirmationBeeps: Bool) {
         func done() {
             DispatchQueue.main.async { [weak self] in
                 if let self = self {
                     self.confirmationBeepsTableViewCell.updateTextLabel(enabled: self.pumpManager.confirmationBeeps)
                     self.confirmationBeepsTableViewCell.isLoading = false
-                    self.extendedBeepsTableViewCell.isEnabled = self.pumpManager.confirmationBeeps
+                    let silenced = self.pumpManager.silencePod
+                    self.confirmationBeepsTableViewCell.isEnabled = !silenced
+                    self.extendedBeepsTableViewCell.isEnabled = !silenced && self.pumpManager.confirmationBeeps
                 }
             }
         }
@@ -791,15 +874,17 @@ extension OmniBLESettingsViewController: PodStateObserver {
             return
         }
 
-        let reloadRows: [StatusRow] = [.podActiveClock, .bolus, .basal, .reservoirLevel, .deliveredInsulin]
-        self.tableView.reloadRows(at: reloadRows.map({ IndexPath(row: $0.rawValue, section: statusIdx) }), with: .none)
-
-        if oldState?.activeAlerts != state?.activeAlerts,
-            let alerts = state?.activeAlerts,
+        let reloadRows: [StatusRow]
+        if oldState?.activeAlertSlots != state?.activeAlertSlots,
+            let alerts = state?.activeAlertSlots,
             let alertCell = self.tableView.cellForRow(at: IndexPath(row: StatusRow.alarms.rawValue, section: statusIdx)) as? AlarmsTableViewCell
         {
             alertCell.alerts = alerts
+            reloadRows = [.podActive, .bolus, .basal, .reservoirLevel, .deliveredInsulin, .alarms]
+        } else {
+            reloadRows = [.podActive, .bolus, .basal, .reservoirLevel, .deliveredInsulin]
         }
+        self.tableView.reloadRows(at: reloadRows.map({ IndexPath(row: $0.rawValue, section: statusIdx) }), with: .none)
     }
 
     func podConnectionStateDidChange(isConnected: Bool) {
@@ -820,6 +905,7 @@ extension OmniBLESettingsViewController: PumpManagerStatusObserver {
 extension OmniBLESettingsViewController: DatePickerTableViewCellDelegate {
     func datePickerTableViewCellDidUpdateDate(_ cell: DatePickerTableViewCell) {
         pumpManager.expirationReminderDate = cell.date
+        setExpirationReminderDate(expirationReminderDate: cell.date)
     }
 }
 
@@ -889,13 +975,13 @@ class AlarmsTableViewCell: LoadingTableViewCell {
         self.detailTextLabel?.isHidden = isLoading
     }
     
-    var alerts = [AlertSlot: PodAlert]() {
+    var alerts: AlertSet = .none {
         didSet {
             updateColor()
             if alerts.isEmpty {
                 detailTextLabel?.text = LocalizedString("None", comment: "Alerts detail when no alerts unacknowledged")
             } else {
-                detailTextLabel?.text = alerts.map { slot, alert in String.init(describing: alert) }.joined(separator: ", ")
+                detailTextLabel?.text = alertString(alerts: alerts)
             }
         }
     }

--- a/OmniBLETests/AcknowledgeAlertsTests.swift
+++ b/OmniBLETests/AcknowledgeAlertsTests.swift
@@ -23,7 +23,7 @@ class AcknowledgeAlertsTests: XCTestCase {
             let cmd = try AcknowledgeAlertCommand(encodedData: Data(hexadecimalString: "11052f9b5b2f10")!)
             XCTAssertEqual(.acknowledgeAlert,cmd.blockType)
             XCTAssertEqual(0x2f9b5b2f, cmd.nonce)
-            XCTAssert(cmd.alerts.contains(.slot4))
+            XCTAssert(cmd.alerts.contains(.slot4LowReservoir))
         } catch (let error) {
             XCTFail("message decoding threw error: \(error)")
         }

--- a/OmniBLETests/MessageTests.swift
+++ b/OmniBLETests/MessageTests.swift
@@ -263,49 +263,49 @@ class MessageTests: XCTestCase {
         do {
             // Decode
             let status = try StatusResponse(encodedData: Data(hexadecimalString: "1d28008200004446ebff")!)
-            XCTAssert(status.alerts.contains(.slot3))
-            XCTAssert(status.alerts.contains(.slot7))
+            XCTAssert(status.alerts.contains(.slot3ExpirationReminder))
+            XCTAssert(status.alerts.contains(.slot7Expired))
         } catch (let error) {
             XCTFail("message decoding threw error: \(error)")
         }
     }
     
     func testConfigureAlertsCommand() {
-        // 79a4 10df 0502
-        // Pod expires 1 minute short of 3 days
-        let podSoftExpirationTime = TimeInterval(hours:72) - TimeInterval(minutes:1)
-        let alertConfig1 = AlertConfiguration(alertType: .slot7, active: true, autoOffModifier: false, duration: .hours(7), trigger: .timeUntilAlert(podSoftExpirationTime), beepRepeat: .every60Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        XCTAssertEqual("79a410df0502", alertConfig1.data.hexadecimalString)
+        // 020f 0000 0202
+        let alertConfig0 = AlertConfiguration(alertType: .slot0AutoOff, active: false, duration: .minutes(15), trigger: .timeUntilAlert(0), beepRepeat: .every1MinuteFor15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, autoOffModifier: true)
+        XCTAssertEqual("020f00000202", alertConfig0.data.hexadecimalString)
 
         // 2800 1283 0602
         let podHardExpirationTime = TimeInterval(hours:79) - TimeInterval(minutes:1)
-        let alertConfig2 = AlertConfiguration(alertType: .slot2, active: true, autoOffModifier: false, duration: .minutes(0), trigger: .timeUntilAlert(podHardExpirationTime), beepRepeat: .every15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
+        let alertConfig2 = AlertConfiguration(alertType: .slot2ShutdownImminent, active: true, duration: .minutes(0), trigger: .timeUntilAlert(podHardExpirationTime), beepRepeat: .every15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
         XCTAssertEqual("280012830602", alertConfig2.data.hexadecimalString)
 
-        // 020f 0000 0202
-        let alertConfig3 = AlertConfiguration(alertType: .slot0, active: false, autoOffModifier: true, duration: .minutes(15), trigger: .timeUntilAlert(0), beepRepeat: .every1MinuteFor15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        XCTAssertEqual("020f00000202", alertConfig3.data.hexadecimalString)
-        
-        let configureAlerts = ConfigureAlertsCommand(nonce: 0xfeb6268b, configurations:[alertConfig1, alertConfig2, alertConfig3])
-        XCTAssertEqual("1916feb6268b79a410df0502280012830602020f00000202", configureAlerts.data.hexadecimalString)
-        
+        // 79a4 10df 0502
+        // Pod expires 1 minute short of 3 days
+        let podSoftExpirationTime = TimeInterval(hours:72) - TimeInterval(minutes:1)
+        let alertConfig7 = AlertConfiguration(alertType: .slot7Expired, active: true, duration: .hours(7), trigger: .timeUntilAlert(podSoftExpirationTime), beepRepeat: .every60Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
+        XCTAssertEqual("79a410df0502", alertConfig7.data.hexadecimalString)
+
+        let configureAlerts = ConfigureAlertsCommand(nonce: 0xfeb6268b, configurations:[alertConfig0, alertConfig2, alertConfig7])
+        XCTAssertEqual("1916feb6268b020f0000020228001283060279a410df0502", configureAlerts.data.hexadecimalString)
+
         do {
             let decoded = try ConfigureAlertsCommand(encodedData: Data(hexadecimalString: "1916feb6268b79a410df0502280012830602020f00000202")!)
             XCTAssertEqual(3, decoded.configurations.count)
-            
+
             let config1 = decoded.configurations[0]
-            XCTAssertEqual(.slot7, config1.slot)
+            XCTAssertEqual(.slot7Expired, config1.slot)
             XCTAssertEqual(true, config1.active)
             XCTAssertEqual(false, config1.autoOffModifier)
             XCTAssertEqual(.hours(7), config1.duration)
-            if case AlertTrigger.timeUntilAlert(let duration) = config1.trigger {
-                XCTAssertEqual(podSoftExpirationTime, duration)
+            if case AlertTrigger.timeUntilAlert(let triggerTime) = config1.trigger {
+                XCTAssertEqual(podSoftExpirationTime, triggerTime)
             }
             XCTAssertEqual(.every60Minutes, config1.beepRepeat)
             XCTAssertEqual(.bipBeepBipBeepBipBeepBipBeep, config1.beepType)
-            
+
             let cfg = try AlertConfiguration(encodedData: Data(hexadecimalString: "4c0000640102")!)
-            XCTAssertEqual(.slot4, cfg.slot)
+            XCTAssertEqual(.slot4LowReservoir, cfg.slot)
             XCTAssertEqual(true, cfg.active)
             XCTAssertEqual(false, cfg.autoOffModifier)
             XCTAssertEqual(0, cfg.duration)
@@ -314,7 +314,6 @@ class MessageTests: XCTestCase {
             }
             XCTAssertEqual(.every1MinuteFor3MinutesAndRepeatEvery60Minutes, cfg.beepRepeat)
             XCTAssertEqual(.bipBeepBipBeepBipBeepBipBeep, cfg.beepType)
-
 
         } catch (let error) {
             XCTFail("message decoding threw error: \(error)")


### PR DESCRIPTION
+ New CustomDebugStringConvertible extension for AlertTrigger
+ Add new optional silent Bool parameter to AlertConfiguration struct
+ Updated CustomDebugStringConvertible extension for AlertConfiguration
+ Add new optional silent Bool associated value for most PodAlert enum values
+ Add new offset TimeInterval associated value for time based PodAlert enum values
+ Updated AlertSlot naming to make slot to alert mappings consistent
+ Use consistent ascending alert ordering for all switch statements
+ New alertString func to return suitable String for a given AlertSet
+ New func to create corresponding PodAlerts for current pod time and silent values
+ Add new silent Bool to ConfigureAlertsCommand struct
+ Sort alert configurations in ConfigureAlertsCommand for easier analysis
+ Have ConfigureAlertsCommand enforce the max alert duration value
+ Rework pump manager code to use new silencePod var
+ Use { } instead of ({ }) for {set,modify}State for consistency & clarity
+ Add timeActive var to pump manager for more accurate pod active time
+ Have acknowlegePodAlerts() use AlertSet instead of [AlertSlot: PodAlert]
+ New setSilencePod pump manager func to change the pod's silence state
+ Add prototype pump manager updateExpirationReminder for Loop dev testing
+ Add prototype pump manager updateLowReservoirReminder for Loop dev testing
+ Add some additional pump manager error logging statements
+ Add new silencePod var to the pump manager state
+ Rework PodAlerts creation for new podActive time offset and silence values
+ New PodState var's to manage pod time active state
+ Remove no longer needed activeAlerts PodState var func
+ Update updatePodTimes func to manages new time active var's
+ Update all unit tests as needed for new names & members
+ Rework UI to use updated simplied interfaces for alertStrings from AlertSlots
+ Add new Pod Settings button for Silence Pod and Unsilence Pod
+ Update UI to use new new pod active pod state
+ Make default suspend time 30 minutes instead of being untimed
+ Have Pod Settings UI set the pod's expiration reminder alert
+ Various commenting additions/updates/improvements/corrections

+ Remove unneeded @discardResult modifier for mutateState() when just using setState()
+ Improved PodCommsError recoverySuggestion for noResponse and podNotConnected