### PR TITLE
Backport name changes and improvements from iAPS integration

### DIFF
--- a/OmniBLE/OmnipodCommon/AlertSlot.swift
+++ b/OmniBLE/OmnipodCommon/AlertSlot.swift
@@ -10,8 +10,11 @@
 import Foundation
 
 fileprivate let defaultShutdownImminentTime = Pod.serviceDuration - Pod.endOfServiceImminentWindow
-fileprivate let defaultExpirationReminderTime = Pod.nominalPodLife - Pod.expirationAlertWindow
+fileprivate let defaultExpirationReminderTime = Pod.nominalPodLife - Pod.defaultExpirationReminderOffset
 fileprivate let defaultExpiredTime = Pod.nominalPodLife
+
+// PDM and pre-SwiftUI use every1MinuteFor3MinutesAndRepeatEvery15Minutes, but with SwiftUI use every15Minutes
+fileprivate let suspendTimeExpiredBeepRepeat = BeepRepeat.every1MinuteFor3MinutesAndRepeatEvery15Minutes
 
 public enum AlertTrigger {
     case unitsRemaining(Double)
@@ -118,7 +121,8 @@ public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
     case podSuspendedReminder(active: Bool, offset: TimeInterval, suspendTime: TimeInterval, timePassed: TimeInterval = 0, silent: Bool = false)
 
     // slot6SuspendTimeExpired: pod suspend time expired alarm, after suspendTime;
-    // 2 sets of beeps every minute for 3 minutes repeated every 15 minutes
+    // 2 sets of beeps every minute for 3 minutes repeated every 15 minutes (PDM & pre-SwiftUI implementations)
+    // 2 sets of beeps every 15 minutes (for SwiftUI PumpManagerAlerts implementations)
     case suspendTimeExpired(offset: TimeInterval, suspendTime: TimeInterval, silent: Bool = false)
 
     // slot7Expired: 2 hours long, time for user to start pairing process
@@ -259,7 +263,7 @@ public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
             let beepType: BeepType
             if active {
                 trigger = .timeUntilAlert(suspendTime)
-                beepRepeat = .every1MinuteFor3MinutesAndRepeatEvery15Minutes
+                beepRepeat = suspendTimeExpiredBeepRepeat
                 beepType = .bipBeepBipBeepBipBeepBipBeep
             } else {
                 trigger = .timeUntilAlert(.minutes(0))
@@ -479,28 +483,28 @@ public enum AlertSlot: UInt8 {
     }
 
     public typealias AllCases = [AlertSlot]
-    
+
     static var allCases: AllCases {
         return (0..<8).map { AlertSlot(rawValue: $0)! }
     }
 }
 
 public struct AlertSet: RawRepresentable, Collection, CustomStringConvertible, Equatable {
-    
+
     public typealias RawValue = UInt8
     public typealias Index = Int
-    
+
     public let startIndex: Int
     public let endIndex: Int
-    
+
     private let elements: [AlertSlot]
-    
+
     public static let none = AlertSet(rawValue: 0)
-    
+
     public var rawValue: UInt8 {
         return elements.reduce(0) { $0 | $1.bitMaskValue }
     }
-    
+
     public init(slots: [AlertSlot]) {
         self.elements = slots
         self.startIndex = 0
@@ -514,11 +518,11 @@ public struct AlertSet: RawRepresentable, Collection, CustomStringConvertible, E
     public subscript(index: Index) -> AlertSlot {
         return elements[index]
     }
-    
+
     public func index(after i: Int) -> Int {
         return i+1
     }
-    
+
     public var description: String {
         if elements.count == 0 {
             return LocalizedString("No alerts", comment: "Pod alert state when no alerts are active")
@@ -544,14 +548,15 @@ public func hasActiveSuspendAlert(configuredAlerts: [AlertSlot : PodAlert]) -> B
     return false
 }
 
-// Returns a descriptive string for alerts set in alerts
-public func alertString(alerts: AlertSet) -> String {
+// Returns a descriptive string for all the alerts in alertSet
+public func alertSetString(alertSet: AlertSet) -> String {
 
-    if alerts.isEmpty {
-        return String(describing: alerts)
+    if alertSet.isEmpty {
+        // Don't bother displaying any additional info for an inactive alert
+        return String(describing: alertSet)
     }
 
-    let alertDescription = alerts.map { (slot) -> String in
+    let alertDescription = alertSet.map { (slot) -> String in
         switch slot {
         case .slot0AutoOff:
             return PodAlert.autoOff(active: true, offset: 0, countdownDuration: 0).description
@@ -562,11 +567,11 @@ public func alertString(alerts: AlertSet) -> String {
         case .slot3ExpirationReminder:
             return PodAlert.expirationReminder(offset: 0, absAlertTime: defaultExpirationReminderTime).description
         case .slot4LowReservoir:
-            return PodAlert.lowReservoir(units: 1).description
+            return PodAlert.lowReservoir(units: Pod.maximumReservoirReading).description
         case .slot5SuspendedReminder:
             return PodAlert.podSuspendedReminder(active: true, offset: 0, suspendTime: .minutes(30)).description
         case .slot6SuspendTimeExpired:
-            return PodAlert.suspendTimeExpired(offset: 0, suspendTime: 1).description
+            return PodAlert.suspendTimeExpired(offset: 0, suspendTime: .minutes(30)).description
         case .slot7Expired:
             return PodAlert.expired(offset: 0, absAlertTime: defaultExpiredTime, duration: Pod.expirationAdvisoryWindow).description
         }
@@ -575,10 +580,44 @@ public func alertString(alerts: AlertSet) -> String {
     return alertDescription.joined(separator: ", ")
 }
 
-// Returns a proper set of PodAlerts based on the pod timeActive and silent boolean
-// for all the configuredAlerts that are still active and not expired
-func createPodAlerts(configuredAlerts: [AlertSlot: PodAlert], activeAlertSlots: AlertSet, timeActive: TimeInterval, silent: Bool) -> [PodAlert] {
+func configuredAlertsString(configuredAlerts: [AlertSlot : PodAlert]) -> String {
 
+    if configuredAlerts.isEmpty {
+        return String(describing: configuredAlerts)
+    }
+
+    let configuredAlertString = configuredAlerts.map { (configuredAlert) -> String in
+
+        let podAlert = configuredAlert.value
+        let description = podAlert.description
+        guard podAlert.configuration.active else {
+            return description
+        }
+
+        switch podAlert {
+        case .shutdownImminent(_, let absAlertTime, _):
+            return String(format: "%@ @ %@", description, absAlertTime.timeIntervalStr)
+        case .expirationReminder(_, let absAlertTime, _, _):
+            return String(format: "%@ @ %@", description, absAlertTime.timeIntervalStr)
+        case .lowReservoir(let unitTrigger, _):
+            return String(format: "%@ @ %dU", description, Int(unitTrigger))
+        case .podSuspendedReminder(_, let offset, let suspendTime, _, _):
+            return String(format: "%@ ending @ %@ after %@", description, (offset + suspendTime).timeIntervalStr, suspendTime.timeIntervalStr)
+        case .suspendTimeExpired(let offset, let suspendTime, _):
+            return String(format: "%@ @ %@ after %@", description, (offset + suspendTime).timeIntervalStr, suspendTime.timeIntervalStr)
+        case .expired(_, let absAlertTime, _, _):
+            return String(format: "%@ @ %@", description, absAlertTime.timeIntervalStr)
+        default:
+            return ""
+        }
+    }
+
+    return configuredAlertString.joined(separator: ", ")
+}
+
+// Returns an array of appropriate PodAlerts with the specified silent value
+// for all the configuredAlerts given all the current pod conditions.
+func regeneratePodAlerts(silent: Bool, configuredAlerts: [AlertSlot: PodAlert], activeAlertSlots: AlertSet, currentPodTime: TimeInterval, currentReservoirLevel: Double) -> [PodAlert] {
     var podAlerts: [PodAlert] = []
 
     for alert in configuredAlerts {
@@ -593,19 +632,19 @@ func createPodAlerts(configuredAlerts: [AlertSlot: PodAlert], activeAlertSlots: 
         case .shutdownImminent(let offset, let alertTime, _):
             // alertTime is absolute when offset is non-zero, otherwise use  default value
             var absAlertTime = offset != 0 ? alertTime : defaultShutdownImminentTime
-            if timeActive >= absAlertTime {
+            if currentPodTime >= absAlertTime {
                 // alert trigger is not in the future, make inactive using a 0 value
                 absAlertTime = 0
             }
             // create new shutdownImminent podAlert using the current timeActive and the original absolute alert time
-            podAlerts.append(PodAlert.shutdownImminent(offset: timeActive, absAlertTime: absAlertTime, silent: silent))
+            podAlerts.append(PodAlert.shutdownImminent(offset: currentPodTime, absAlertTime: absAlertTime, silent: silent))
 
         case .expirationReminder(let offset, let alertTime, let alertDuration, _):
             let duration: TimeInterval
 
             // alertTime is absolute when offset is non-zero, otherwise use default value
             var absAlertTime = offset != 0 ? alertTime : defaultExpirationReminderTime
-            if timeActive >= absAlertTime {
+            if currentPodTime >= absAlertTime {
                 // alert trigger is not in the future, make inactive using a 0 value
                 absAlertTime = 0
                 duration = 0
@@ -613,14 +652,20 @@ func createPodAlerts(configuredAlerts: [AlertSlot: PodAlert], activeAlertSlots: 
                 duration = alertDuration
             }
             // create new expirationReminder podAlert using the current active time and the original absolute alert time and duration
-            podAlerts.append(PodAlert.expirationReminder(offset: timeActive, absAlertTime: absAlertTime, duration: duration, silent: silent))
+            podAlerts.append(PodAlert.expirationReminder(offset: currentPodTime, absAlertTime: absAlertTime, duration: duration, silent: silent))
 
-        case .lowReservoir(let units, _):
-            // trivial with no time trigger issues to worry about
+        case .lowReservoir(let unitTrigger, _):
+            let units: Double
+            if currentReservoirLevel > unitTrigger {
+                units = unitTrigger
+            } else {
+                // reservoir is no longer more than the unitTrigger, make inactive using a 0 value
+                units = 0
+            }
             podAlerts.append(PodAlert.lowReservoir(units: units, silent: silent))
 
         case .podSuspendedReminder(let active, let offset, let suspendTime, _, _):
-            let timePassed: TimeInterval = min(timeActive - offset, .hours(2))
+            let timePassed: TimeInterval = min(currentPodTime - offset, .hours(2))
             // Pass along the computed time passed since alert was originally set so creation routine can
             // do all the grunt work dealing with varying reminder intervals and time passing scenarios.
             podAlerts.append(PodAlert.podSuspendedReminder(active: active, offset: offset, suspendTime: suspendTime, timePassed: timePassed, silent: silent))
@@ -628,30 +673,35 @@ func createPodAlerts(configuredAlerts: [AlertSlot: PodAlert], activeAlertSlots: 
         case .suspendTimeExpired(let lastOffset, let lastSuspendTime, _):
             let absAlertTime = lastOffset + lastSuspendTime
             let suspendTime: TimeInterval
-            if timeActive >= absAlertTime {
+            if currentPodTime >= absAlertTime {
                 // alert trigger is no longer in the future
                 if activeAlertSlots.contains(where: { $0 == .slot6SuspendTimeExpired } ) {
                     // The suspendTimeExpired alert has yet been acknowledged,
-                    // reconfigure this alert to trigger again in one minute.
-                    suspendTime = TimeInterval(minutes: 1)
+                    // set up a suspendTimeExpired alert for the next 15m interval.
+                    // Compute a new suspendTime that is a multiple of 15 minutes
+                    // from lastOffset which is at least one minute in the future.
+                    let newOffsetSuspendTime = ceil((currentPodTime - lastOffset) / .minutes(15)) * .minutes(15)
+                    let newAbsAlertTime = lastOffset + newOffsetSuspendTime
+                    suspendTime = max(newAbsAlertTime - currentPodTime, .minutes(1))
                 } else {
-                    // The suspendTimeExpired alert was already been acknowleged,
+                    // The suspendTimeExpired alert was already been acknowledged,
                     // so now make this alert inactive by using a 0 suspendTime.
                     suspendTime = 0
                 }
             } else {
                 // recompute a new suspendTime based on the current pod time
-                suspendTime = absAlertTime - timeActive
+                suspendTime = absAlertTime - currentPodTime
+                print("setting new suspendTimeExpired suspendTime of \(suspendTime) with currentPodTime\(currentPodTime) and absAlertTime=\(absAlertTime)")
             }
-            // create a new suspendTimeExpired PodAlert using the current active time and remaining suspend time (if any)
-            podAlerts.append(PodAlert.suspendTimeExpired(offset: timeActive, suspendTime: suspendTime, silent: silent))
+            // create a new suspendTimeExpired PodAlert using the current active time and the computed suspendTime (if any)
+            podAlerts.append(PodAlert.suspendTimeExpired(offset: currentPodTime, suspendTime: suspendTime, silent: silent))
 
         case .expired(let offset, let alertTime, let alertDuration, _):
             let duration: TimeInterval
 
             // alertTime is absolute when offset is non-zero, otherwise use default value
             var absAlertTime = offset != 0 ? alertTime : defaultExpiredTime
-            if timeActive >= absAlertTime {
+            if currentPodTime >= absAlertTime {
                 // alert trigger is not in the future, make inactive using a 0 value
                 absAlertTime = 0
                 duration = 0
@@ -659,7 +709,7 @@ func createPodAlerts(configuredAlerts: [AlertSlot: PodAlert], activeAlertSlots: 
                 duration = alertDuration
             }
             // create new expired podAlert using the current active time and the original absolute alert time and duration
-            podAlerts.append(PodAlert.expired(offset: timeActive, absAlertTime: absAlertTime, duration: duration, silent: silent))
+            podAlerts.append(PodAlert.expired(offset: currentPodTime, absAlertTime: absAlertTime, duration: duration, silent: silent))
 
         default:
             break

--- a/OmniBLE/OmnipodCommon/Pod.swift
+++ b/OmniBLE/OmnipodCommon/Pod.swift
@@ -31,9 +31,6 @@ public struct Pod {
     // Units per second for priming/cannula insertion
     public static let primeDeliveryRate: Double = Pod.pulseSize / Pod.secondsPerPrimePulse
 
-    // User configured time before expiration advisory (PDM allows 1-24 hours)
-    public static let expirationAlertWindow = TimeInterval(hours: 2)
-
     // Expiration advisory window: time after expiration alert, and end of service imminent alarm
     public static let expirationAdvisoryWindow = TimeInterval(hours: 7)
 
@@ -82,9 +79,18 @@ public struct Pod {
     public static let cannulaInsertionUnitsExtra = 0.0 // edit to add a fixed additional amount of insulin during cannula insertion
 
     // Default and limits for expiration reminder alerts
-    public static let expirationReminderAlertDefaultTimeBeforeExpiration = TimeInterval.hours(2)
+    public static let defaultExpirationReminderOffset = TimeInterval(hours: 2)
     public static let expirationReminderAlertMinTimeBeforeExpiration = TimeInterval.hours(1)
     public static let expirationReminderAlertMaxTimeBeforeExpiration = TimeInterval.hours(24)
+
+    // Threshold used to display pod end of life warnings
+    public static let timeRemainingWarningThreshold = TimeInterval(days: 1)
+
+    // Default low reservoir alert limit in Units
+    public static let defaultLowReservoirReminder: Double = 10
+
+    // Allowed Low Reservoir reminder values
+    public static let allowedLowReservoirReminderValues = Array(stride(from: 10, through: 50, by: 1))
 }
 
 // DeliveryStatus used in StatusResponse and DetailedStatus

--- a/OmniBLE/PumpManager/OmniBLEPumpManagerState.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManagerState.swift
@@ -133,7 +133,7 @@ public struct OmniBLEPumpManagerState: RawRepresentable, Equatable {
         if let expirationReminderDate = rawValue["expirationReminderDate"] as? Date {
             self.expirationReminderDate = expirationReminderDate
         } else if let expiresAt = podState?.expiresAt {
-            self.expirationReminderDate = expiresAt.addingTimeInterval(-Pod.expirationReminderAlertDefaultTimeBeforeExpiration)
+            self.expirationReminderDate = expiresAt.addingTimeInterval(-Pod.defaultExpirationReminderOffset)
         }
 
         if let rawUnstoredDoses = rawValue["unstoredDoses"] as? [UnfinalizedDose.RawValue] {
@@ -204,7 +204,7 @@ extension OmniBLEPumpManagerState: CustomDebugStringConvertible {
             "* extendedBeeps: \(String(describing: extendedBeeps))",
             "* controllerId: \(String(format: "%08X", controllerId))",
             "* podId: \(String(format: "%08X", podId))",
-            String(reflecting: podState),
+            "* PodState: " + (podState == nil ? "nil\n" : String(describing: podState!)),
         ].joined(separator: "\n")
     }
 }

--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -369,10 +369,16 @@ public class PodCommsSession {
     }
 
     @discardableResult
-    func configureAlerts(_ alerts: [PodAlert], beepBlock: MessageBlock? = nil) throws -> StatusResponse {
+    func configureAlerts(_ alerts: [PodAlert], acknowledgeAll: Bool = false, beepBlock: MessageBlock? = nil) throws -> StatusResponse {
         let configurations = alerts.map { $0.configuration }
         let configureAlerts = ConfigureAlertsCommand(nonce: podState.currentNonce, configurations: configurations)
-        let status: StatusResponse = try send([configureAlerts], beepBlock: beepBlock)
+        var blocksToSend: [MessageBlock] = [configureAlerts]
+        if acknowledgeAll {
+            // requested to acknowledge any possible pending pod alerts out of an abundnace of caution
+            let acknowledgeAll = AcknowledgeAlertCommand(nonce: podState.currentNonce, alerts: AlertSet(rawValue: ~0))
+            blocksToSend += [acknowledgeAll]
+        }
+        let status: StatusResponse = try send(blocksToSend, beepBlock: beepBlock)
         for alert in alerts {
             podState.registerConfiguredAlert(slot: alert.configuration.slot, alert: alert)
         }
@@ -429,12 +435,12 @@ public class PodCommsSession {
             }
             podState.updateFromStatusResponse(status)
         } else {
-            let elapsed: TimeInterval = -(podState.timeActiveUpdated?.timeIntervalSinceNow ?? 0)
-            let podActive = podState.timeActive + elapsed
+            let elapsed: TimeInterval = -(podState.podTimeUpdated?.timeIntervalSinceNow ?? 0)
+            let podTime = podState.podTime + elapsed
 
             // Configure the Pod Alerts for shutdown imminent alert (79 hours) and pod expiration alert (72 hours)
-            let shutdownImminentAlarm = PodAlert.shutdownImminent(offset: podActive, absAlertTime: Pod.serviceDuration - Pod.endOfServiceImminentWindow, silent: silent)
-            let expirationAdvisoryAlarm = PodAlert.expired(offset: podActive, absAlertTime: Pod.nominalPodLife, duration: Pod.expirationAdvisoryWindow, silent: silent)
+            let shutdownImminentAlarm = PodAlert.shutdownImminent(offset: podTime, absAlertTime: Pod.serviceDuration - Pod.endOfServiceImminentWindow, silent: silent)
+            let expirationAdvisoryAlarm = PodAlert.expired(offset: podTime, absAlertTime: Pod.nominalPodLife, duration: Pod.expirationAdvisoryWindow, silent: silent)
             try configureAlerts([shutdownImminentAlarm, expirationAdvisoryAlarm])
         }
         
@@ -642,9 +648,9 @@ public class PodCommsSession {
             var podSuspendedReminderAlert: PodAlert? = nil
             var suspendTimeExpiredAlert: PodAlert? = nil
             let suspendTime = suspendReminder ?? 0
-            let elapsed: TimeInterval = -(podState.timeActiveUpdated?.timeIntervalSinceNow ?? 0)
-            let podActiveTime = podState.timeActive + elapsed
-            log.debug("suspendDelivery: podState.timeActive=%@, elapsed=%.2fs, computed timeActive %@", podState.timeActive.timeIntervalStr, elapsed, podActiveTime.timeIntervalStr)
+            let elapsed: TimeInterval = -(podState.podTimeUpdated?.timeIntervalSinceNow ?? 0)
+            let podTime = podState.podTime + elapsed
+            log.debug("suspendDelivery: podState.podTime=%@, elapsed=%.2fs, computed podTime %@", podState.podTime.timeIntervalStr, elapsed, podTime.timeIntervalStr)
 
             let cancelDeliveryCommand = CancelDeliveryCommand(nonce: podState.currentNonce, deliveryType: .all, beepType: .noBeepCancel)
             var commandsToSend: [MessageBlock] = [cancelDeliveryCommand]
@@ -652,14 +658,14 @@ public class PodCommsSession {
             // podSuspendedReminder provides a periodic pod suspended reminder beep until the specified suspend time.
             if suspendReminder != nil && (suspendTime == 0 || suspendTime > .minutes(5)) {
                 // using reminder beeps for an untimed or long enough suspend time requiring pod suspended reminders
-                podSuspendedReminderAlert = PodAlert.podSuspendedReminder(active: true, offset: podActiveTime, suspendTime: suspendTime, silent: silent)
+                podSuspendedReminderAlert = PodAlert.podSuspendedReminder(active: true, offset: podTime, suspendTime: suspendTime, silent: silent)
                 alertConfigurations += [podSuspendedReminderAlert!.configuration]
             }
 
             // suspendTimeExpired provides suspend time expired alert beeping after the expected suspend time has passed.
             if suspendTime > 0 {
                 // a timed suspend using a suspend time expired alert
-                suspendTimeExpiredAlert = PodAlert.suspendTimeExpired(offset: podActiveTime, suspendTime: suspendTime, silent: silent)
+                suspendTimeExpiredAlert = PodAlert.suspendTimeExpired(offset: podTime, suspendTime: suspendTime, silent: silent)
                 alertConfigurations += [suspendTimeExpiredAlert!.configuration]
             }
 

--- a/OmniBLE/PumpManager/PodState.swift
+++ b/OmniBLE/PumpManager/PodState.swift
@@ -59,8 +59,8 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
     public var activatedAt: Date?
     public var expiresAt: Date? // set based on timeActive and can change with Pod clock drift and/or system time change
 
-    public var timeActive: TimeInterval // pod active time from each response, always whole minute values
-    public var timeActiveUpdated: Date? // time that timeActive value was last updated
+    public var podTime: TimeInterval // pod time from the last response, always whole minute values
+    public var podTimeUpdated: Date? // time that the podTime value was last updated
 
     public var setupUnitsDelivered: Double?
 
@@ -136,7 +136,7 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         self.bleIdentifier = bleIdentifier
         self.deliveryStatusVerified = false
         self.lastCommsOK = false
-        self.timeActive = 0
+        self.podTime = 0
     }
 
     public var unfinishedSetup: Bool {
@@ -186,11 +186,14 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
     private mutating func updatePodTimes(timeActive: TimeInterval) -> Date {
         let now = Date()
 
-        // Don't use a zero timeActive value after a reset type pod fault
-        if timeActive != 0 || self.timeActiveUpdated == nil {
-            self.timeActive = timeActive
-            self.timeActiveUpdated = now
+        guard timeActive >= self.podTime else {
+            // The pod active time went backwards and thus we have an apparent reset fault.
+            // Don't update any times or displayed expiresAt time will expectedly jump.
+            return now
         }
+
+        self.podTime = timeActive
+        self.podTimeUpdated = now
 
         let activatedAtComputed = now - timeActive
         if activatedAt == nil {
@@ -414,14 +417,14 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
             }
         }
 
-        if let timeActive = rawValue["timeActive"] as? TimeInterval,
-            let timeActiveUpdated = rawValue["timeActiveUpdated"] as? Date
+        if let podTime = rawValue["podTime"] as? TimeInterval,
+            let podTimeUpdated = rawValue["podTimeUpdated"] as? Date
         {
-            self.timeActive = timeActive
-            self.timeActiveUpdated = timeActiveUpdated
+            self.podTime = podTime
+            self.podTimeUpdated = podTimeUpdated
         } else {
-            self.timeActive = 0
-            self.timeActiveUpdated = nil
+            self.podTime = 0
+            self.podTimeUpdated = nil
         }
 
         if let setupUnitsDelivered = rawValue["setupUnitsDelivered"] as? Double {
@@ -566,8 +569,8 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         rawValue["primeFinishTime"] = primeFinishTime
         rawValue["activatedAt"] = activatedAt
         rawValue["expiresAt"] = expiresAt
-        rawValue["timeActive"] = timeActive
-        rawValue["timeActiveUpdated"] = timeActiveUpdated
+        rawValue["podTime"] = podTime
+        rawValue["podTimeUpdated"] = podTimeUpdated
         rawValue["setupUnitsDelivered"] = setupUnitsDelivered
 
         if configuredAlerts.count > 0 {
@@ -588,8 +591,8 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
             "* bleIdentifier: \(bleIdentifier)",
             "* activatedAt: \(String(reflecting: activatedAt))",
             "* expiresAt: \(String(reflecting: expiresAt))",
-            "* timeActive: \(timeActive.timeIntervalStr)",
-            "* timeActiveUpdated: \(String(reflecting: timeActiveUpdated))",
+            "* podTime: \(podTime.timeIntervalStr)",
+            "* podTimeUpdated: \(String(reflecting: podTimeUpdated))",
             "* setupUnitsDelivered: \(String(reflecting: setupUnitsDelivered))",
             "* firmwareVersion: \(firmwareVersion)",
             "* bleFirmwareVersion: \(bleFirmwareVersion)",
@@ -602,13 +605,13 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
             "* unfinalizedSuspend: \(String(describing: unfinalizedSuspend))",
             "* unfinalizedResume: \(String(describing: unfinalizedResume))",
             "* finalizedDoses: \(String(describing: finalizedDoses))",
-            "* activeAlerts: \(alertString(alerts: activeAlertSlots))",
+            "* activeAlertsSlots: \(alertSetString(alertSet: activeAlertSlots))",
             "* messageTransportState: \(String(describing: messageTransportState))",
             "* setupProgress: \(setupProgress)",
             "* primeFinishTime: \(String(describing: primeFinishTime))",
-            "* configuredAlerts: \(String(describing: configuredAlerts))",
-            "",
-            fault != nil ? String(reflecting: fault!) : "fault: nil",
+            "* configuredAlerts: \(configuredAlertsString(configuredAlerts: configuredAlerts))",
+            "* PdmRef: " + (fault?.pdmRef == nil ? "nil" : String(describing: fault!.pdmRef!)),
+            "* Fault: " + (fault == nil ? "nil" : String(describing: fault!)),
             "",
         ].joined(separator: "\n")
     }

--- a/OmniBLE/PumpManagerUI/OmniBLEHUDProvider.swift
+++ b/OmniBLE/PumpManagerUI/OmniBLEHUDProvider.swift
@@ -157,7 +157,7 @@ internal class OmniBLEHUDProvider: NSObject, HUDProvider, PodStateObserver {
                 lifetime = 0
             }
             rawValue["lifetime"] = lifetime
-            rawValue["alerts"] = alertString(alerts: podState.activeAlertSlots)
+            rawValue["alerts"] = alertSetString(alertSet: podState.activeAlertSlots)
         }
         
         if let lastInsulinMeasurements = podState?.lastInsulinMeasurements {

--- a/OmniBLE/PumpManagerUI/ViewControllers/CommandResponseViewController.swift
+++ b/OmniBLE/PumpManagerUI/ViewControllers/CommandResponseViewController.swift
@@ -70,7 +70,7 @@ extension CommandResponseViewController {
 
         result += String(format: LocalizedString("Reservoir Level: %1$@ U\n", comment: "The format string for Reservoir Level: (1: reservoir level string)"), status.reservoirLevel == Pod.reservoirLevelAboveThresholdMagicNumber ? "50+" : status.reservoirLevel.twoDecimals)
 
-        result += String(format: LocalizedString("Alerts: %1$@\n", comment: "The format string for Alerts: (1: the alerts string)"), alertString(alerts: status.unacknowledgedAlerts))
+        result += String(format: LocalizedString("Alerts: %1$@\n", comment: "The format string for Alerts: (1: the alerts string)"), alertSetString(alertSet: status.unacknowledgedAlerts))
 
         if status.radioRSSI != 0 {
             result += String(format: LocalizedString("RSSI: %1$@\n", comment: "The format string for RSSI: (1: RSSI value)"), String(describing: status.radioRSSI))

--- a/OmniBLE/PumpManagerUI/ViewControllers/OmniBLESettingsViewController.swift
+++ b/OmniBLE/PumpManagerUI/ViewControllers/OmniBLESettingsViewController.swift
@@ -393,7 +393,7 @@ class OmniBLESettingsViewController: UITableViewController {
             case .podActive:
                 let cell = tableView.dequeueReusableCell(withIdentifier: NSStringFromClass(SettingsTableViewCell.self), for: indexPath)
                 cell.textLabel?.text = LocalizedString("Pod Active", comment: "The title of the cell showing pod active time")
-                cell.setDetailAge(self.pumpManager.timeActive)
+                cell.setDetailAge(self.pumpManager.podTime)
                 return cell
             case .bolus:
                 cell.textLabel?.text = LocalizedString("Bolus Delivery", comment: "The title of the cell showing pod bolus status")
@@ -981,7 +981,7 @@ class AlarmsTableViewCell: LoadingTableViewCell {
             if alerts.isEmpty {
                 detailTextLabel?.text = LocalizedString("None", comment: "Alerts detail when no alerts unacknowledged")
             } else {
-                detailTextLabel?.text = alertString(alerts: alerts)
+                detailTextLabel?.text = alertSetString(alertSet: alerts)
             }
         }
     }

--- a/OmniBLEParser/main.swift
+++ b/OmniBLEParser/main.swift
@@ -183,7 +183,11 @@ for arg in CommandLine.arguments[1...] {
             // 2023-09-02T00:29:04-0700 [DeviceManager] DeviceDataManager.swift - deviceManager(_:logEventForDeviceIdentifier:type:message:completion:) - 563 - DEV: Device message: 17b3931b08030e01008205
             // 2023-09-02T00:29:04-0700 [DeviceManager] DeviceDataManager.swift - deviceManager(_:logEventForDeviceIdentifier:type:message:completion:) - 563 - DEV: Device message: 17b3931b0c0a1d1800b48000000683ff017d
             case Regex("Device message: [0-9a-fA-F]+$"):
-                parseIAPSLogLine(line)
+                // Don't mistakenly match an iaps xcode log file line as an iaps log file line
+                // 2023-10-28 22:37:24.584982-0700 FreeAPS[6030:4151040] [DeviceManager] DeviceDataManager.swift - deviceManager(_:logEventForDeviceIdentifier:type:message:completion:) - 563 DEV: Device message: 17eed3be3824191c494e532e2800069406024c0001f4010268000000060279a404f005021e040300000001ca
+                if !line.contains(" FreeAPS") {
+                    parseIAPSLogLine(line)
+                }
 
             default:
                 break


### PR DESCRIPTION
+ Rename podState timeActive -> podTime for better clarity
+ Rename alertString() -> alertSetString() for clarity & consistency
+ New configuredAlertString() that displays trigger information
+ Improved podState debugDescription formatting
+ Acknowledge all alerts when reseting flipping silence pod state
+ Use 15 minute reminders when changing silence pod after suspend time expired
+ CreatePodAlerts() generalized and named regeneratePodAlerts()
+ Make lowReservoir alert inactive if pod reservoir level is below limit
Add additional OmniBLEParser test to prevent potential duplicate matches