### PR TITLE
More pod pump manager related fixes and improvements

### DIFF
--- a/OmniBLE/OmnipodCommon/MessageBlocks/PodInfoActivationTime.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/PodInfoActivationTime.swift
@@ -36,7 +36,7 @@ public struct PodInfoActivationTime : PodInfo {
         self.day    = Int(encodedData[13])
         self.hour   = Int(encodedData[15])
         self.minute = Int(encodedData[16])
-        self.data = Data(encodedData)
+        self.data   = Data(encodedData)
     }
 }
 
@@ -51,8 +51,8 @@ func activationTimeString(podInfoActivationTime: PodInfoActivationTime) -> Strin
     result.append(String(format: "Minute: %u", podInfoActivationTime.minute))
 
     // pod fault info
-    result.append(String(format: "\n%@", String(describing: podInfoActivationTime.faultEventCode)))
-    result.append(String(format: "Fault Time: %@", podInfoActivationTime.faultTime.timeIntervalStr))
+    result.append(String(format: "\nFault Time: %@", podInfoActivationTime.faultTime.timeIntervalStr))
+    result.append(String(describing: podInfoActivationTime.faultEventCode))
 
     return result.joined(separator: "\n")
 }

--- a/OmniBLE/OmnipodCommon/MessageBlocks/PodInfoPulseLogPlus.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/PodInfoPulseLogPlus.swift
@@ -44,8 +44,8 @@ public struct PodInfoPulseLogPlus : PodInfo {
         self.nEntries = nEntries
         self.maxEntries = maxEntries
         self.faultEventCode = FaultEventCode(rawValue: encodedData[1])
-        self.timeFaultEvent = TimeInterval(minutes: Double((Int(encodedData[2] & 0b1) << 8) + Int(encodedData[3])))
-        self.timeActivation = TimeInterval(minutes: Double((Int(encodedData[4] & 0b1) << 8) + Int(encodedData[5])))
+        self.timeFaultEvent = TimeInterval(minutes: Double((Int(encodedData[2]) << 8) + Int(encodedData[3])))
+        self.timeActivation = TimeInterval(minutes: Double((Int(encodedData[4]) << 8) + Int(encodedData[5])))
         self.pulseLog = createPulseLog(encodedData: encodedData, logStartByteOffset: logStartByteOffset, nEntries: self.nEntries)
         self.data = encodedData
     }

--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -788,9 +788,9 @@ public class PodCommsSession {
         let basalExtraCommand = BasalScheduleExtraCommand.init(schedule: schedule, scheduleOffset: scheduleOffset, acknowledgementBeep: acknowledgementBeep, programReminderInterval: programReminderInterval)
 
         do {
-            if !(podState.lastCommsOK && podState.deliveryStatusVerified) {
-                // Can't trust the current delivery state -- do a cancel all
-                // to be sure that setting a basal program won't fault the pod.
+            if podState.setupProgress == .completed && !(podState.lastCommsOK && podState.deliveryStatusVerified) {
+                // The pod setup is complete and the current delivery state can't be trusted so
+                // do a cancel all to be sure that setting the basal program won't fault the pod.
                 let _: StatusResponse = try send([CancelDeliveryCommand(nonce: podState.currentNonce, deliveryType: .all, beepType: .noBeepCancel)])
             }
             let status: StatusResponse = try send([basalScheduleCommand, basalExtraCommand])


### PR DESCRIPTION
+ Add fix for 0x31 fault during pod setup when pod state is indeterminate
+ Fix implementation bug in PodInfoPulseLogPlus limiting pod time to 9 bits
+ Fix pod pump managers not to crash if an incorrect response type is returned
+ Add safeguards for possible edge cases to prevent 0x31 faults before pod is set up
+ Adjust activationTimeString to better match pulseLogPlusString's output