### PR TITLE
Random small updates from iAPS & Loop work

### DIFF
--- a/OmniBLE/OmnipodCommon/AlertSlot.swift
+++ b/OmniBLE/OmnipodCommon/AlertSlot.swift
@@ -58,7 +58,7 @@ public struct AlertConfiguration {
 
     static let length = 6
 
-    public init(alertType: AlertSlot, active: Bool = true, duration: TimeInterval = 0, trigger: AlertTrigger, beepRepeat: BeepRepeat, beepType: BeepType, silent: Bool = false, autoOffModifier: Bool = false)
+    public init(alertType: AlertSlot, active: Bool = true, duration: TimeInterval = 0, trigger: AlertTrigger, beepRepeat: BeepRepeat, beepType: BeepType, silent: Bool, autoOffModifier: Bool = false)
     {
         self.slot = alertType
         self.active = active
@@ -180,7 +180,7 @@ public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
 
         // slot1NotUsed
         case .notUsed:
-            return AlertConfiguration(alertType: .slot1NotUsed, duration: .minutes(55), trigger: .timeUntilAlert(.minutes(5)), beepRepeat: .every5Minutes, beepType: .noBeepNonCancel)
+            return AlertConfiguration(alertType: .slot1NotUsed, duration: .minutes(55), trigger: .timeUntilAlert(.minutes(5)), beepRepeat: .every5Minutes, beepType: .noBeepNonCancel, silent: false)
 
         // slot2ShutdownImminent
         case .shutdownImminent(let offset, let absAlertTime, let silent):
@@ -277,12 +277,12 @@ public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
             // After pod is powered up, beep every 10 minutes for up to 2 hours before pairing before failing
             let totalDuration: TimeInterval = .hours(2)
             let startOffset: TimeInterval = .minutes(10)
-            return AlertConfiguration(alertType: .slot7Expired, duration: totalDuration - startOffset, trigger: .timeUntilAlert(startOffset), beepRepeat: .every5Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
+            return AlertConfiguration(alertType: .slot7Expired, duration: totalDuration - startOffset, trigger: .timeUntilAlert(startOffset), beepRepeat: .every5Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: false)
         case .finishSetupReminder:
             // After pod is paired, beep every 5 minutes for up to 1 hour for pod setup to complete before failing
             let totalDuration: TimeInterval = .hours(1)
             let startOffset: TimeInterval = .minutes(5)
-            return AlertConfiguration(alertType: .slot7Expired, duration: totalDuration - startOffset, trigger: .timeUntilAlert(startOffset), beepRepeat: .every5Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
+            return AlertConfiguration(alertType: .slot7Expired, duration: totalDuration - startOffset, trigger: .timeUntilAlert(startOffset), beepRepeat: .every5Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: false)
         case .expired(let offset, let absAlertTime, let duration, let silent):
             // Normally used to alert at Pod.nominalPodLife (72 hours) for Pod.expirationAdvisoryWindow (7 hours)
             // 2 sets of beeps repeating every 60 minutes

--- a/OmniBLE/OmnipodCommon/MessageBlocks/PodInfo.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/PodInfo.swift
@@ -17,11 +17,12 @@ public protocol PodInfo {
 }
 
 public enum PodInfoResponseSubType: UInt8, Equatable {
-    case normal                      = 0x00
+    case normal                      = 0x00 // Returns the normal status response returned by most commands
     case triggeredAlerts             = 0x01 // Returns values for any unacknowledged triggered alerts
     case detailedStatus              = 0x02 // Returns detailed pod status, returned for most calls after a pod fault
     case pulseLogPlus                = 0x03 // Returns up to the last 60 pulse log entries plus additional info
     case activationTime              = 0x05 // Returns pod activation time and possible fault code & fault time
+    case noSeqStatusResponse         = 0x07 // DASH only, returns the normal status response w/o incrementing msg seq #
     case pulseLogRecent              = 0x50 // Returns the last 50 pulse log entries
     case pulseLogPrevious            = 0x51 // Like 0x50, but returns up to the previous 50 entries before the last 50
     
@@ -37,6 +38,8 @@ public enum PodInfoResponseSubType: UInt8, Equatable {
             return PodInfoPulseLogPlus.self
         case .activationTime:
             return PodInfoActivationTime.self
+        case .noSeqStatusResponse:
+            return StatusResponse.self as! PodInfo.Type
         case .pulseLogRecent:
             return PodInfoPulseLogRecent.self
         case .pulseLogPrevious:

--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -357,6 +357,7 @@ public class PodCommsSession {
             podState.updateFromStatusResponse(status)
             if status.podProgressStatus == .basalInitialized {
                 podState.setupProgress = .initialBasalScheduleSet
+                podState.finalizedDoses.append(UnfinalizedDose(resumeStartTime: Date(), scheduledCertainty: .certain))
                 return
             }
         }

--- a/OmniBLETests/MessageTests.swift
+++ b/OmniBLETests/MessageTests.swift
@@ -272,18 +272,18 @@ class MessageTests: XCTestCase {
     
     func testConfigureAlertsCommand() {
         // 020f 0000 0202
-        let alertConfig0 = AlertConfiguration(alertType: .slot0AutoOff, active: false, duration: .minutes(15), trigger: .timeUntilAlert(0), beepRepeat: .every1MinuteFor15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, autoOffModifier: true)
+        let alertConfig0 = AlertConfiguration(alertType: .slot0AutoOff, active: false, duration: .minutes(15), trigger: .timeUntilAlert(0), beepRepeat: .every1MinuteFor15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: false, autoOffModifier: true)
         XCTAssertEqual("020f00000202", alertConfig0.data.hexadecimalString)
 
         // 2800 1283 0602
         let podHardExpirationTime = TimeInterval(hours:79) - TimeInterval(minutes:1)
-        let alertConfig2 = AlertConfiguration(alertType: .slot2ShutdownImminent, active: true, duration: .minutes(0), trigger: .timeUntilAlert(podHardExpirationTime), beepRepeat: .every15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
+        let alertConfig2 = AlertConfiguration(alertType: .slot2ShutdownImminent, active: true, duration: .minutes(0), trigger: .timeUntilAlert(podHardExpirationTime), beepRepeat: .every15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: false)
         XCTAssertEqual("280012830602", alertConfig2.data.hexadecimalString)
 
         // 79a4 10df 0502
         // Pod expires 1 minute short of 3 days
         let podSoftExpirationTime = TimeInterval(hours:72) - TimeInterval(minutes:1)
-        let alertConfig7 = AlertConfiguration(alertType: .slot7Expired, active: true, duration: .hours(7), trigger: .timeUntilAlert(podSoftExpirationTime), beepRepeat: .every60Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
+        let alertConfig7 = AlertConfiguration(alertType: .slot7Expired, active: true, duration: .hours(7), trigger: .timeUntilAlert(podSoftExpirationTime), beepRepeat: .every60Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: false)
         XCTAssertEqual("79a410df0502", alertConfig7.data.hexadecimalString)
 
         let configureAlerts = ConfigureAlertsCommand(nonce: 0xfeb6268b, configurations:[alertConfig0, alertConfig2, alertConfig7])


### PR DESCRIPTION
+ Remove default value for silent parameter to AlertConfiguration.init()
+ Add noSeqStatusResponse case for DASH only type 7 PodInfoResponse
+ Add missing finalizeDoses call for resuming basal during pod setup